### PR TITLE
Pref Refactor

### DIFF
--- a/src/mods/ballcolor.cpp
+++ b/src/mods/ballcolor.cpp
@@ -30,9 +30,9 @@ void tick() {
     // Set ball & ape color to color ID
     if (mkb::balls[mkb::curr_player_idx].ape != nullptr) {  // Check for nullpointers first
         mkb::balls[mkb::curr_player_idx].ape->color_index =
-            convert_to_ape_color_id(pref::get_ape_color());
+            convert_to_ape_color_id(pref::get(pref::U8Pref::ApeColor));
         mkb::balls[mkb::curr_player_idx].g_ball_color_index =
-            convert_to_ball_color_id(pref::get_ball_color());
+            convert_to_ball_color_id(pref::get(pref::U8Pref::BallColor));
     }
 }
 

--- a/src/mods/banans.cpp
+++ b/src/mods/banans.cpp
@@ -8,7 +8,7 @@ namespace banans {
 static bool s_prev_enabled = false;
 
 void tick() {
-    bool enabled = pref::get_9999_banana_counter();
+    bool enabled = pref::get(pref::BoolPref::BananaCounter9999);
     if (enabled != s_prev_enabled) {
         s_prev_enabled = enabled;
         if (enabled) {

--- a/src/mods/cmseg.cpp
+++ b/src/mods/cmseg.cpp
@@ -145,12 +145,12 @@ static void check_exit_seg() {
 static void state_seg_active() {
     // Set character
     if (mkb::sub_mode_request == mkb::SMD_GAME_READY_INIT) {
-        Chara ch = static_cast<Chara>(pref::get_cm_chara());
+        Chara ch = static_cast<Chara>(pref::get(pref::U8Pref::CmChara));
         mkb::ApeCharacter real_chara;
         if (ch == Chara::Random) {
             real_chara = s_ape_charas[mkb::rand() % 4];
         } else {
-            real_chara = s_ape_charas[pref::get_cm_chara()];
+            real_chara = s_ape_charas[pref::get(pref::U8Pref::CmChara)];
         }
         mkb::active_monkey_id[0] = real_chara;
     }
@@ -348,7 +348,7 @@ void tick() {
 }
 
 void disp() {
-    if (!pref::get_cm_timer()) return;
+    if (!pref::get(pref::BoolPref::CmTimer)) return;
 
     if (s_state == State::SegActive || s_state == State::SegComplete) {
         u32 seg = static_cast<u32>(s_seg_request);

--- a/src/mods/dpad.cpp
+++ b/src/mods/dpad.cpp
@@ -7,7 +7,7 @@
 namespace dpad {
 
 void on_PADRead(mkb::PADStatus* statuses) {
-    if (!pref::get_dpad_controls()) return;
+    if (!pref::get(pref::BoolPref::DpadControls)) return;
 
     for (u32 i = 0; i < 4; i++) {
         mkb::PADStatus& status = statuses[i];

--- a/src/mods/freecam.cpp
+++ b/src/mods/freecam.cpp
@@ -20,7 +20,7 @@ static S16Vec s_fcRot = {};
 static patch::Tramp<decltype(&mkb::event_camera_tick)> s_event_camera_tick_tramp;
 
 static void update_cam(mkb::Camera* camera, mkb::Ball* ball) {
-    bool enabledNow = pref::get_freecam();
+    bool enabledNow = pref::get(pref::BoolPref::Freecam);
     if (enabledNow != s_enabledPrevTick) {
         s_enabledPrevTick = enabledNow;
         if (enabledNow) {
@@ -72,7 +72,7 @@ static void update_cam(mkb::Camera* camera, mkb::Ball* ball) {
 
 void init() {
     patch::hook_function(s_event_camera_tick_tramp, mkb::event_camera_tick, []() {
-        if (pref::get_freecam()) {
+        if (pref::get(pref::BoolPref::Freecam)) {
             for (u32 i = 0; i < LEN(mkb::world_infos); i++) {
                 mkb::world_infos[i].stage_tilt_x = 0;
                 mkb::world_infos[i].stage_tilt_z = 0;
@@ -83,7 +83,7 @@ void init() {
 }
 
 void tick() {
-    bool enabledNow = pref::get_freecam();
+    bool enabledNow = pref::get(pref::BoolPref::Freecam);
     if (enabledNow != s_enabledPrevTick) {
         s_enabledPrevTick = enabledNow;
         if (enabledNow) {

--- a/src/mods/freeze.cpp
+++ b/src/mods/freeze.cpp
@@ -12,7 +12,7 @@ void init() {
     // TODO use a generic pre-draw hook instead of hooking this important function?
     patch::hook_function(s_event_info_tick_tramp, mkb::event_info_tick, []() {
         s_event_info_tick_tramp.dest();
-        if (pref::get_freeze_timer()) {
+        if (pref::get(pref::BoolPref::FreezeTimer)) {
             mkb::mode_info.stage_time_frames_remaining = mkb::mode_info.stage_time_limit;
         }
     });

--- a/src/mods/hidebg.cpp
+++ b/src/mods/hidebg.cpp
@@ -9,7 +9,9 @@ namespace hidebg {
 static patch::Tramp<decltype(&mkb::g_draw_bg)> s_draw_bg_tramp;
 static patch::Tramp<decltype(&mkb::g_set_clear_color)> s_clear_tramp;
 
-static bool should_hide_bg() { return pref::get_hide_bg() && mkb::main_mode != mkb::MD_ADV; }
+static bool should_hide_bg() {
+    return pref::get(pref::BoolPref::HideBg) && mkb::main_mode != mkb::MD_ADV;
+}
 
 static void avdisp_set_fog_color_hook(u8 r, u8 g, u8 b) {
     if (should_hide_bg()) {

--- a/src/mods/ilbattle.cpp
+++ b/src/mods/ilbattle.cpp
@@ -32,7 +32,6 @@ static constexpr u32 CHEIGHT = 16;
 static bool s_invalid_pause = false;
 static u32 s_buzzer_message_count = 0;
 static u32 s_battle_length = 0;
-// static u32 battle_length = pref::get_ilbattle_length();
 
 static void battle_display(mkb::GXColor color) {
     u32 battle_minutes = s_battle_frames % HOUR_FRAMES / MINUTE_FRAMES;
@@ -50,7 +49,7 @@ static void battle_display(mkb::GXColor color) {
     draw::debug_text(X, Y + CHEIGHT, color, "%d.%02d", best_seconds, best_centiseconds);
     draw::debug_text(X - 12 * CWIDTH, Y + 2 * CHEIGHT, color, "BEST SCORE:");
     draw::debug_text(X, Y + 2 * CHEIGHT, color, "%d", s_best_score);
-    if (pref::get_il_battle_breakdown()) {
+    if (pref::get(pref::BoolPref::IlBattleBreakdown)) {
         draw::debug_text(X - 12 * CWIDTH, Y + 3 * CHEIGHT, draw::GOLD, "SCORE BREAKDOWN");
         draw::debug_text(X - 12 * CWIDTH, Y + 4 * CHEIGHT, color, "BANANAS:");
         draw::debug_text(X, Y + 4 * CHEIGHT, color, "%d", s_best_score_bananas);
@@ -89,7 +88,7 @@ void clear_display() {
     s_buzzer_message_count = 0;
     s_best_score_bananas = 0;
     s_best_score_frames = 0;
-    s_battle_length = convert_battle_length(pref::get_il_battle_length());
+    s_battle_length = convert_battle_length(pref::get(pref::U8Pref::IlBattleLength));
 }
 
 void new_battle() {
@@ -106,7 +105,7 @@ static void track_first_retry() {
 }
 
 static void run_battle_timer() {
-    if (pref::get_il_battle_length() != 3) {  // If the timer isnt endless
+    if (pref::get(pref::U8Pref::IlBattleLength) != 3) {  // If the timer isnt endless
         if (s_battle_frames < s_battle_length) {
             s_battle_frames++;
         } else
@@ -167,7 +166,7 @@ static void track_final_attempt() {
 static void display_buzzer_beater_message() {
     s_buzzer_message_count++;
     u32 Y2 = Y;
-    if (pref::get_il_battle_breakdown()) Y2 = Y + 3 * CHEIGHT;
+    if (pref::get(pref::BoolPref::IlBattleBreakdown)) Y2 = Y + 3 * CHEIGHT;
     if (s_buzzer_message_count >= 0)
         draw::debug_text(X - 12 * CWIDTH, Y2 + 3 * CHEIGHT, draw::RED, "EPIC BUZZER BEATER B)");
     if (s_buzzer_message_count >= 5)
@@ -185,7 +184,7 @@ static void display_buzzer_beater_message() {
 }
 
 void tick() {
-    if (pref::get_il_battle_display()) {
+    if (pref::get(pref::BoolPref::IlBattleDisplay)) {
         if (s_state == IlBattleState::WaitForFirstRetry) {
             track_first_retry();
         } else if (s_state == IlBattleState::BattleRunning) {
@@ -214,7 +213,7 @@ void tick() {
 }
 
 void disp() {
-    if (pref::get_il_battle_display()) {
+    if (pref::get(pref::BoolPref::IlBattleDisplay)) {
         if (s_state == IlBattleState::WaitForFirstRetry && mkb::main_mode == mkb::MD_GAME) {
             draw::debug_text(X - 12 * CWIDTH, Y, draw::GOLD, "READY");
             draw::debug_text(X - 12 * CWIDTH, Y + CHEIGHT, draw::GOLD, "(RETRY TO BEGIN)");

--- a/src/mods/ilmark.cpp
+++ b/src/mods/ilmark.cpp
@@ -28,12 +28,13 @@ void tick() {
         bool dpad_down =
             pad::button_down(mkb::PAD_BUTTON_DOWN) || pad::button_down(mkb::PAD_BUTTON_LEFT) ||
             pad::button_down(mkb::PAD_BUTTON_RIGHT) || pad::button_down(mkb::PAD_BUTTON_UP);
-        if (pref::get_dpad_controls() && dpad_down) s_valid_run = false;
+        if (pref::get(pref::BoolPref::DpadControls) && dpad_down) s_valid_run = false;
 
         // Using these tools/mods at all is disallowed
-        bool using_disallowed_mod = pref::get_freeze_timer() || pref::get_freecam() ||
-                                    pref::get_debug_mode() || pref::get_jump_mod() ||
-                                    pref::get_moon() || pref::get_marathon();
+        bool using_disallowed_mod =
+            pref::get(pref::BoolPref::FreezeTimer) || pref::get(pref::BoolPref::Freecam) ||
+            pref::get(pref::BoolPref::DebugMode) || pref::get(pref::BoolPref::JumpMod) ||
+            pref::get(pref::BoolPref::Moon) || pref::get(pref::BoolPref::Marathon);
         if (using_disallowed_mod) s_valid_run = false;
 
         // Opening the mod menu is disallowed
@@ -45,11 +46,11 @@ void disp() {
     if (mkb::main_mode != mkb::MD_GAME) return;
 
     if (mkb::main_game_mode == mkb::PRACTICE_MODE) {
-        if (!pref::get_il_mark_practice()) return;
+        if (!pref::get(pref::BoolPref::IlMarkPractice)) return;
     } else if (mkb::main_game_mode == mkb::STORY_MODE) {
-        if (!pref::get_il_mark_story()) return;
+        if (!pref::get(pref::BoolPref::IlMarkStory)) return;
     } else if (mkb::main_game_mode == mkb::CHALLENGE_MODE) {
-        if (!pref::get_il_mark_challenge()) return;
+        if (!pref::get(pref::BoolPref::IlMarkChallenge)) return;
     } else {
         return;
     }

--- a/src/mods/inputdisp.cpp
+++ b/src/mods/inputdisp.cpp
@@ -2,10 +2,10 @@
 
 #include "mkb/mkb.h"
 
-#include "utils/draw.h"
 #include "systems/pad.h"
-#include "utils/patch.h"
 #include "systems/pref.h"
+#include "utils/draw.h"
+#include "utils/patch.h"
 
 namespace inputdisp {
 
@@ -131,8 +131,9 @@ void on_PADRead(mkb::PADStatus* statuses) {
 }
 
 void tick() {
-    set_sprite_visible(!pref::get_input_disp() || (pref::get_input_disp_center_location() &&
-                                                   !pref::get_input_disp_raw_stick_inputs()));
+    set_sprite_visible(!pref::get(pref::BoolPref::InputDisp) ||
+                       (pref::get(pref::BoolPref::InputDispCenterLocation) &&
+                        !pref::get(pref::BoolPref::InputDispRawStickInputs)));
 }
 
 static bool get_notch_pos(const MergedStickInputs& stickInputs, Vec2d* out_pos) {
@@ -180,7 +181,7 @@ static const mkb::GXColor s_color_map[] = {
 };
 
 static void draw_stick(const MergedStickInputs& stickInputs, const Vec2d& center, f32 scale) {
-    mkb::GXColor chosen_color = s_color_map[pref::get_input_disp_color()];
+    mkb::GXColor chosen_color = s_color_map[pref::get(pref::U8Pref::InputDispColor)];
 
     draw_ring(8, center, 54 * scale, 60 * scale, {0x00, 0x00, 0x00, 0xFF});
     draw_circle(8, center, 54 * scale, {0x00, 0x00, 0x00, 0x7F});
@@ -223,7 +224,7 @@ static void draw_buttons(const Vec2d& center, f32 scale) {
 
 static void draw_notch_indicators(const MergedStickInputs& stickInputs, const Vec2d& center,
                                   f32 scale) {
-    if (!pref::get_input_disp_notch_indicators()) return;
+    if (!pref::get(pref::BoolPref::InputDispNotchIndicators)) return;
 
     Vec2d notch_norm = {};
     if (get_notch_pos(stickInputs, &notch_norm)) {
@@ -236,10 +237,10 @@ static void draw_notch_indicators(const MergedStickInputs& stickInputs, const Ve
 }
 
 static void draw_raw_stick_inputs(const MergedStickInputs& stickInputs) {
-    if (!pref::get_input_disp_raw_stick_inputs()) return;
+    if (!pref::get(pref::BoolPref::InputDispRawStickInputs)) return;
 
     Vec2d center = {
-        .x = pref::get_input_disp_center_location() ? 540.f : 390.f,
+        .x = pref::get(pref::BoolPref::InputDispCenterLocation) ? 540.f : 390.f,
         .y = 28.f,
     };
 
@@ -250,9 +251,10 @@ static void draw_raw_stick_inputs(const MergedStickInputs& stickInputs) {
 }
 
 void disp() {
-    if (!pref::get_input_disp()) return;
+    if (!pref::get(pref::BoolPref::InputDisp)) return;
 
-    Vec2d center = pref::get_input_disp_center_location() ? Vec2d{430, 60} : Vec2d{534, 60};
+    Vec2d center =
+        pref::get(pref::BoolPref::InputDispCenterLocation) ? Vec2d{430, 60} : Vec2d{534, 60};
     f32 scale = 0.6f;
 
     MergedStickInputs stickInputs;

--- a/src/mods/iw.cpp
+++ b/src/mods/iw.cpp
@@ -118,7 +118,7 @@ void tick() {
 }
 
 void disp() {
-    if (!pref::get_iw_timer() || mkb::main_mode != mkb::MD_GAME ||
+    if (!pref::get(pref::BoolPref::IwTimer) || mkb::main_mode != mkb::MD_GAME ||
         mkb::main_game_mode != mkb::STORY_MODE || !main::currently_playing_iw)
         return;
     timerdisp::draw_timer(static_cast<s32>(s_iw_time), "IW:", 0, draw::WHITE, false);

--- a/src/mods/jump.cpp
+++ b/src/mods/jump.cpp
@@ -189,7 +189,7 @@ void tick() {
     //        }
     //    }
 
-    bool enabled = pref::get_jump_mod();
+    bool enabled = pref::get(pref::BoolPref::JumpMod);
     if (enabled != s_prev_enabled) {
         s_prev_enabled = enabled;
         if (enabled) {

--- a/src/mods/marathon.cpp
+++ b/src/mods/marathon.cpp
@@ -98,7 +98,7 @@ static void wait_for_apply() {
 }
 
 void tick() {
-    if (pref::get_marathon()) {
+    if (pref::get(pref::BoolPref::Marathon)) {
         if (s_state == MarathonState::WaitForGoal) {
             wait_for_goal();
         } else if (s_state == MarathonState::StoringVel) {

--- a/src/mods/moon.cpp
+++ b/src/mods/moon.cpp
@@ -12,7 +12,7 @@ static void moon_gravity() {
 }
 
 void tick() {
-    if (pref::get_moon()) {
+    if (pref::get(pref::BoolPref::Moon)) {
         moon_gravity();
     }
 }

--- a/src/mods/savest_ui.cpp
+++ b/src/mods/savest_ui.cpp
@@ -25,7 +25,7 @@ static bool is_either_trigger_held() {
 }
 
 void tick() {
-    if (!pref::get_savestates()) return;
+    if (!pref::get(pref::BoolPref::Savestates)) return;
 
     // Must tick savestates every frame
     for (u32 i = 0; i < LEN(s_states); i++) {

--- a/src/mods/sfx.cpp
+++ b/src/mods/sfx.cpp
@@ -1,8 +1,8 @@
 #include "sfx.h"
 
 #include "mkb/mkb.h"
-#include "utils/patch.h"
 #include "systems/pref.h"
+#include "utils/patch.h"
 
 namespace sfx {
 
@@ -12,18 +12,18 @@ static patch::Tramp<decltype(&mkb::call_SoundReqID_arg_0)> s_call_SoundReqID_arg
 void init() {
     // Only hook if the preference is initially set, so we don't affect background music until game
     // is rebooted
-    if (pref::get_mute_bgm()) {
+    if (pref::get(pref::BoolPref::MuteBgm)) {
         patch::hook_function(
             s_SoftStreamStart_tramp, mkb::SoftStreamStart,
             [](u32 g_looping_state, mkb::BgmTrack g_bgm_id, u32 param_3) -> s32 { return 0; });
     }
 
-    patch::hook_function(s_call_SoundReqID_arg_0_tramp, mkb::call_SoundReqID_arg_0,
-                         [](u32 g_sfx_idx) {
-                             if (!(pref::get_mute_timer_ding() && g_sfx_idx == 0x0003d806)) {
-                                 s_call_SoundReqID_arg_0_tramp.dest(g_sfx_idx);
-                             }
-                         });
+    patch::hook_function(
+        s_call_SoundReqID_arg_0_tramp, mkb::call_SoundReqID_arg_0, [](u32 g_sfx_idx) {
+            if (!(pref::get(pref::BoolPref::MuteTimerDing) && g_sfx_idx == 0x0003d806)) {
+                s_call_SoundReqID_arg_0_tramp.dest(g_sfx_idx);
+            }
+        });
 }
 
 }  // namespace sfx

--- a/src/mods/timer.cpp
+++ b/src/mods/timer.cpp
@@ -51,7 +51,7 @@ void disp() {
         }
     }
 
-    if (pref::get_rta_pause_timer()) {
+    if (pref::get(pref::BoolPref::RtaPauseTimer)) {
         timerdisp::draw_timer(s_rta_timer, "RTA:", 1, draw::WHITE, true);
         timerdisp::draw_timer(s_pause_timer, "PAU:", 2, draw::WHITE, true);
     }

--- a/src/mods/unlock.cpp
+++ b/src/mods/unlock.cpp
@@ -36,10 +36,10 @@ void init() {
     char gamecode[7] = {};
     mkb::memcpy(gamecode, mkb::DVD_GAME_NAME, 6);
     if (mkb::strcmp(gamecode, "GM2E8P") == 0) {
-        if (pref::get_unlock_vanilla()) {
+        if (pref::get(pref::BoolPref::UnlockVanilla)) {
             s_flags |= Flags::ShouldUnlock;
         }
-    } else if (pref::get_unlock_romhacks()) {
+    } else if (pref::get(pref::BoolPref::UnlockRomhacks)) {
         s_flags |= Flags::ShouldUnlock;
     }
 }

--- a/src/systems/log.cpp
+++ b/src/systems/log.cpp
@@ -1,13 +1,31 @@
 #include "log.h"
 
+#include <cstdarg>
+
 namespace log {
 
 void mod_assert(const char* file, s32 line, bool exp) {
     if (!(exp)) {
-        mkb::OSPanic(const_cast<char*>(file), line, "[pracmod] Assertion failed");
+        mkb::OSPanic(const_cast<char*>(file), line, "[wsmod] Assertion failed");
         while (true)
             ;
     }
+}
+
+[[noreturn]] void abort() {
+    mkb::OSReport("[wsmod] Aborted. See above for error messages.\n");
+    while (true)
+        ;
+}
+
+[[noreturn]] void abort(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    mkb::vprintf(const_cast<char*>(format), args);
+    va_end(args);
+
+    while (true)
+        ;
 }
 
 }  // namespace log

--- a/src/systems/log.cpp
+++ b/src/systems/log.cpp
@@ -1,31 +1,13 @@
 #include "log.h"
 
-#include <cstdarg>
-
 namespace log {
 
 void mod_assert(const char* file, s32 line, bool exp) {
     if (!(exp)) {
-        mkb::OSPanic(const_cast<char*>(file), line, "[wsmod] Assertion failed");
+        mkb::OSPanic(const_cast<char*>(file), line, "[pracmod] Assertion failed");
         while (true)
             ;
     }
-}
-
-[[noreturn]] void abort() {
-    mkb::OSReport("[wsmod] Aborted. See above for error messages.\n");
-    while (true)
-        ;
-}
-
-[[noreturn]] void abort(const char *format, ...) {
-    va_list args;
-    va_start(args, format);
-    mkb::vprintf(const_cast<char*>(format), args);
-    va_end(args);
-
-    while (true)
-        ;
 }
 
 }  // namespace log

--- a/src/systems/log.h
+++ b/src/systems/log.h
@@ -3,7 +3,22 @@
 #include "mkb/mkb.h"
 
 namespace log {
-void mod_assert(const char* file, s32 line, bool exp);
-}
 
+// To save space and because it just makes more sense, we differentiate
+// user-facing error messages from assertion failures meant for developers.
+//
+// abort() is for user-caused errors, with clear error messages to help resolve
+// the problem.
+//
+// MOD_ASSERT() includes line/col number of assertion failure but not a message,
+// which is more appropriate for a developer.
+
+void mod_assert(const char *file, s32 line, bool exp);
+
+[[noreturn]] void abort();
+[[noreturn]] void abort(const char *format, ...);
+
+} // namespace log
+
+// Factor as much out of the macro as possible to save space
 #define MOD_ASSERT(exp) (log::mod_assert(__FILE__, __LINE__, (exp)))

--- a/src/systems/log.h
+++ b/src/systems/log.h
@@ -3,22 +3,7 @@
 #include "mkb/mkb.h"
 
 namespace log {
+void mod_assert(const char* file, s32 line, bool exp);
+}
 
-// To save space and because it just makes more sense, we differentiate
-// user-facing error messages from assertion failures meant for developers.
-//
-// abort() is for user-caused errors, with clear error messages to help resolve
-// the problem.
-//
-// MOD_ASSERT() includes line/col number of assertion failure but not a message,
-// which is more appropriate for a developer.
-
-void mod_assert(const char *file, s32 line, bool exp);
-
-[[noreturn]] void abort();
-[[noreturn]] void abort(const char *format, ...);
-
-} // namespace log
-
-// Factor as much out of the macro as possible to save space
 #define MOD_ASSERT(exp) (log::mod_assert(__FILE__, __LINE__, (exp)))

--- a/src/systems/main.cpp
+++ b/src/systems/main.cpp
@@ -157,7 +157,7 @@ void init() {
  * controller inputs have been read and processed however, to ensure the lowest input delay.
  */
 void tick() {
-    if (pref::get_debug_mode()) {
+    if (pref::get(pref::BoolPref::DebugMode)) {
         mkb::dip_switches |= mkb::DIP_DEBUG | mkb::DIP_DISP;
     } else {
         mkb::dip_switches &= ~(mkb::DIP_DEBUG | mkb::DIP_DISP);

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -8,7 +8,6 @@
 #include "mods/inputdisp.h"
 #include "mods/jump.h"
 #include "mods/unlock.h"
-#include "systems/pref.h"
 #include "systems/version.h"
 #include "utils/draw.h"
 #include "utils/macro_utils.h"
@@ -30,46 +29,47 @@ static Widget s_inputdisp_widgets[] = {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
-                "Show Input Display",
-                pref::get_input_disp,
-                pref::set_input_disp,
+                .label = "Show Input Display",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::InputDisp,
             },
     },
     {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
-                "Use Center Location",
-                pref::get_input_disp_center_location,
-                pref::set_input_disp_center_location,
+                .label = "Use Center Location",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::InputDispCenterLocation,
             },
     },
     {
         .type = WidgetType::Choose,
-        .choose = {
-            .label = "Color",
-            .choices = inputdisp_colors,
-            .num_choices = LEN(inputdisp_colors),
-            .get = []() { return static_cast<u32>(pref::get_input_disp_color()); },
-            .set = [](u32 color) { pref::set_input_disp_color(static_cast<u8>(color)); },
-        },
-    },
-    {
-        .type = WidgetType::Checkbox,
-        .checkbox =
+        .choose =
             {
-                "Notch Indicators",
-                pref::get_input_disp_notch_indicators,
-                pref::set_input_disp_notch_indicators,
+                .label = "Color",
+                .choices = inputdisp_colors,
+                .num_choices = LEN(inputdisp_colors),
+                .flags = ChooseFlags::Pref,
+                .pref = pref::U8Pref::InputDispColor,
             },
     },
     {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
-                "Raw Stick Inputs",
-                pref::get_input_disp_raw_stick_inputs,
-                pref::set_input_disp_raw_stick_inputs,
+                .label = "Notch Indicators",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::InputDispNotchIndicators,
+            },
+    },
+    {
+        .type = WidgetType::Checkbox,
+        .checkbox =
+            {
+                .label = "Raw Stick Inputs",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::InputDispRawStickInputs,
             },
     },
 };
@@ -82,23 +82,25 @@ static_assert(LEN(s_ball_colors) == ballcolor::NUM_COLORS);
 static Widget s_ball_color_widgets[] = {
     {
         .type = WidgetType::Choose,
-        .choose = {
-            .label = "Ball Color",
-            .choices = s_ball_colors,
-            .num_choices = LEN(s_ball_colors),
-            .get = []() { return static_cast<u32>(pref::get_ball_color()); },
-            .set = [](u32 color) { pref::set_ball_color(static_cast<u8>(color)); },
-        },
+        .choose =
+            {
+                .label = "Ball Color",
+                .choices = s_ball_colors,
+                .num_choices = LEN(s_ball_colors),
+                .flags = ChooseFlags::Pref,
+                .pref = pref::U8Pref::BallColor,
+            },
     },
     {
         .type = WidgetType::Choose,
-        .choose = {
-            .label = "Ape Color",
-            .choices = s_ball_colors,
-            .num_choices = LEN(s_ball_colors),
-            .get = []() { return static_cast<u32>(pref::get_ape_color()); },
-            .set = [](u32 color) { pref::set_ape_color(static_cast<u8>(color)); },
-        },
+        .choose =
+            {
+                .label = "Ape Color",
+                .choices = s_ball_colors,
+                .num_choices = LEN(s_ball_colors),
+                .flags = ChooseFlags::Pref,
+                .pref = pref::U8Pref::ApeColor,
+            },
     },
 };
 
@@ -115,66 +117,77 @@ static Widget s_il_battle_widgets[] = {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
-                "IL Battle Display",
-                pref::get_il_battle_display,
-                pref::set_il_battle_display,
+                .label = "IL Battle Display",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::IlBattleDisplay,
             },
     },
     {
         .type = WidgetType::Choose,
-        .choose = {
-            .label = "Battle Length",
-            .choices = s_il_battle_lengths,
-            .num_choices = LEN(s_il_battle_lengths),
-            .get = []() { return static_cast<u32>(pref::get_il_battle_length()); },
-            .set = [](u32 color) { pref::set_il_battle_length(static_cast<u8>(color)); },
-        },
+        .choose =
+            {
+                .label = "Battle Length",
+                .choices = s_il_battle_lengths,
+                .num_choices = LEN(s_il_battle_lengths),
+                .flags = ChooseFlags::Pref,
+                .pref = pref::U8Pref::IlBattleLength,
+            },
     },
     {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
-                "Score Breakdown Info",
-                pref::get_il_battle_breakdown,
-                pref::set_il_battle_breakdown,
+                .label = "Score Breakdown Info",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::IlBattleBreakdown,
             },
     },
     {.type = WidgetType::Text, .text = {"  Dpad-Down then Retry to start a new battle"}},
 };
 
 static Widget s_rumble_widgets[] = {
-    {
-        .type = WidgetType::Checkbox,
-        .checkbox = {
-            .label = "Controller 1 Rumble",
-            .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 0)); },
-            .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 0); },
-        },
-    },
+    {.type = WidgetType::Checkbox,
+     .checkbox = {
+         .label = "Controller 1 Rumble",
+         .flags = CheckboxFlags::GetterSetter,
+         .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 0)); },
+         .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 0); },
+         .get_default = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 0)); },
+     }},
     {
         .type = WidgetType::Checkbox,
         .checkbox = {
             .label = "Controller 2 Rumble",
+            .flags = CheckboxFlags::GetterSetter,
             .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 1)); },
             .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 1); },
+            .get_default =
+                []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 1)); },
         },
     },
     {
         .type = WidgetType::Checkbox,
         .checkbox = {
             .label = "Controller 3 Rumble",
+            .flags = CheckboxFlags::GetterSetter,
             .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 2)); },
             .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 2); },
+            .get_default =
+                []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 2)); },
         },
     },
     {
         .type = WidgetType::Checkbox,
         .checkbox = {
             .label = "Controller 4 Rumble",
+            .flags = CheckboxFlags::GetterSetter,
             .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 3)); },
             .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 3); },
+            .get_default =
+                []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 3)); },
         },
-    }};
+    },
+};
 
 static Widget s_about_widgets[] = {
     {
@@ -214,13 +227,14 @@ static const char* chara_choices[] = {"AiAi", "MeeMee", "Baby", "GonGon", "Rando
 static Widget s_cm_seg_widgets[] = {
     // Settings
     {.type = WidgetType::Choose,
-     .choose = {
-         .label = "Character",
-         .choices = chara_choices,
-         .num_choices = LEN(chara_choices),
-         .get = [] { return static_cast<u32>(pref::get_cm_chara()); },
-         .set = [](u32 choice) { pref::set_cm_chara(static_cast<u8>(choice)); },
-     }},
+     .choose =
+         {
+             .label = "Character",
+             .choices = chara_choices,
+             .num_choices = LEN(chara_choices),
+             .flags = ChooseFlags::Pref,
+             .pref = pref::U8Pref::CmChara,
+         }},
     {.type = WidgetType::Separator},
 
     // Beginner
@@ -364,16 +378,32 @@ static Widget s_cm_seg_widgets[] = {
 static Widget s_timers_widgets[] = {
     {
         .type = WidgetType::Checkbox,
-        .checkbox = {"RTA+Pause Timer", pref::get_rta_pause_timer, pref::set_rta_pause_timer},
+        .checkbox =
+            {
+                .label = "RTA+Pause Timer",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::RtaPauseTimer,
+            },
     },
     {
         .type = WidgetType::Checkbox,
-        .checkbox = {"Story Mode IW Timer", pref::get_iw_timer, pref::set_iw_timer},
+        .checkbox =
+            {
+                .label = "Story Mode IW Timer",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::IwTimer,
+            },
     },
     {
         .type = WidgetType::Checkbox,
-        .checkbox = {"CM Seg Timer", pref::get_cm_timer, pref::set_cm_timer},
-    }};
+        .checkbox =
+            {
+                .label = "CM Seg Timer",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::CmTimer,
+            },
+    },
+};
 
 static Widget s_savestates_help_widgets[] = {
     {.type = WidgetType::Text, .text = {"  X          \x1c Create savestate"}},
@@ -456,8 +486,8 @@ static Widget s_sound_widgets[] = {
         .checkbox =
             {
                 .label = "Mute Background Music",
-                .get = pref::get_mute_bgm,
-                .set = pref::set_mute_bgm,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::MuteBgm,
             },
     },
     {.type = WidgetType::Text, .text = {"  To apply background music setting:"}},
@@ -469,8 +499,8 @@ static Widget s_sound_widgets[] = {
         .checkbox =
             {
                 .label = "Mute Timer Ding",
-                .get = pref::get_mute_timer_ding,
-                .set = pref::set_mute_timer_ding,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::MuteTimerDing,
             },
     },
 };
@@ -521,11 +551,21 @@ static Widget s_unlock_widgets[] = {
     },
     {
         .type = WidgetType::Checkbox,
-        .checkbox = {"For Vanilla SMB2", pref::get_unlock_vanilla, pref::set_unlock_vanilla},
+        .checkbox =
+            {
+                .label = "For Vanilla SMB2",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::UnlockVanilla,
+            },
     },
     {
         .type = WidgetType::Checkbox,
-        .checkbox = {"For Romhacks", pref::get_unlock_romhacks, pref::set_unlock_romhacks},
+        .checkbox =
+            {
+                .label = "For Romhacks",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::UnlockRomhacks,
+            },
     },
     {
         .type = WidgetType::Text,
@@ -536,28 +576,38 @@ static Widget s_unlock_widgets[] = {
 static Widget s_tools_widgets[] = {
     {
         .type = WidgetType::Checkbox,
-        .checkbox = {"Savestates", pref::get_savestates, pref::set_savestates},
+        .checkbox =
+            {
+                .label = "Savestates",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::Savestates,
+            },
     },
     {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
                 .label = "Freeze Timer",
-                .get = pref::get_freeze_timer,
-                .set = pref::set_freeze_timer,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::FreezeTimer,
             },
     },
     {
         .type = WidgetType::Checkbox,
-        .checkbox = {.label = "Freecam", .get = pref::get_freecam, .set = pref::set_freecam},
+        .checkbox =
+            {
+                .label = "Freecam",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::Freecam,
+            },
     },
     {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
                 .label = "Hide Background",
-                .get = pref::get_hide_bg,
-                .set = pref::set_hide_bg,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::HideBg,
             },
     },
     {.type = WidgetType::Menu, .menu = {"Rumble", s_rumble_widgets, LEN(s_rumble_widgets)}},
@@ -574,8 +624,8 @@ static Widget s_tools_widgets[] = {
         .checkbox =
             {
                 .label = "Debug Mode",
-                .get = pref::get_debug_mode,
-                .set = pref::set_debug_mode,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::DebugMode,
             },
     },
 };
@@ -586,8 +636,8 @@ static Widget s_il_mark_widgets[] = {
         .checkbox =
             {
                 .label = "Show in Practice Mode",
-                .get = pref::get_il_mark_practice,
-                .set = pref::set_il_mark_practice,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::IlMarkPractice,
             },
     },
     {
@@ -595,8 +645,8 @@ static Widget s_il_mark_widgets[] = {
         .checkbox =
             {
                 .label = "Show in Story Mode",
-                .get = pref::get_il_mark_story,
-                .set = pref::set_il_mark_story,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::IlMarkStory,
             },
     },
     {
@@ -604,8 +654,8 @@ static Widget s_il_mark_widgets[] = {
         .checkbox =
             {
                 .label = "Show in Challenge Mode",
-                .get = pref::get_il_mark_challenge,
-                .set = pref::set_il_mark_challenge,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::IlMarkChallenge,
             },
     },
 };
@@ -636,8 +686,8 @@ static Widget s_displays_widgets[] = {
         .checkbox =
             {
                 .label = "9999 Banana Counter",
-                .get = pref::get_9999_banana_counter,
-                .set = pref::set_9999_banana_counter,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::BananaCounter9999,
             },
     },
 };
@@ -648,8 +698,8 @@ static Widget s_gameplay_mods_widgets[] = {
         .checkbox =
             {
                 .label = "Jump Mod",
-                .get = pref::get_jump_mod,
-                .set = pref::set_jump_mod,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::JumpMod,
             },
     },
     {
@@ -657,8 +707,8 @@ static Widget s_gameplay_mods_widgets[] = {
         .checkbox =
             {
                 .label = "Moon Gravity",
-                .get = pref::get_moon,
-                .set = pref::set_moon,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::Moon,
             },
     },
     {
@@ -666,17 +716,19 @@ static Widget s_gameplay_mods_widgets[] = {
         .checkbox =
             {
                 .label = "Marathon Mode",
-                .get = pref::get_marathon,
-                .set = pref::set_marathon,
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::Marathon,
             },
     },
-    {.type = WidgetType::Checkbox,
-     .checkbox =
-         {
-             .label = "D-pad Controls",
-             .get = pref::get_dpad_controls,
-             .set = pref::set_dpad_controls,
-         }},
+    {
+        .type = WidgetType::Checkbox,
+        .checkbox =
+            {
+                .label = "D-pad Controls",
+                .flags = CheckboxFlags::Pref,
+                .pref = pref::BoolPref::DpadControls,
+            },
+    },
 };
 
 static Widget s_root_widgets[] = {

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -1,6 +1,7 @@
 #include "menu_defn.h"
 
 #include "mkb/mkb.h"
+#include "mkb/mkb2_ghidra.h"
 #include "mods/ballcolor.h"
 #include "mods/cmseg.h"
 #include "mods/gotostory.h"
@@ -135,37 +136,50 @@ static Widget s_il_battle_widgets[] = {
     {.type = WidgetType::Text, .text = {"  Dpad-Down then Retry to start a new battle"}},
 };
 
+// Forgive me for putting code in the menu definition
+static bool rumble_get(int controller_idx) {
+    return mkb::rumble_enabled_bitflag & (1 << controller_idx);
+}
+
+static void rumble_set(int controller_idx, bool value) {
+    if (value) {
+        mkb::rumble_enabled_bitflag |= 1 << controller_idx;
+    } else {
+        mkb::rumble_enabled_bitflag &= ~(1 << controller_idx);
+    }
+}
+
 static Widget s_rumble_widgets[] = {
     {
         .type = WidgetType::GetSetCheckbox,
         .get_set_checkbox = {
             .label = "Controller 1 Rumble",
-            .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 0)); },
-            .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 0); },
+            .get = []() { return rumble_get(0); },
+            .set = [](bool enable) { rumble_set(0, enable); },
         },
     },
     {
         .type = WidgetType::GetSetCheckbox,
         .get_set_checkbox = {
             .label = "Controller 2 Rumble",
-            .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 1)); },
-            .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 1); },
+            .get = []() { return rumble_get(1); },
+            .set = [](bool enable) { rumble_set(1, enable); },
         },
     },
     {
         .type = WidgetType::GetSetCheckbox,
         .get_set_checkbox = {
             .label = "Controller 3 Rumble",
-            .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 2)); },
-            .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 2); },
+            .get = []() { return rumble_get(2); },
+            .set = [](bool enable) { rumble_set(2, enable); },
         },
     },
     {
         .type = WidgetType::GetSetCheckbox,
         .get_set_checkbox = {
             .label = "Controller 4 Rumble",
-            .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 3)); },
-            .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 3); },
+            .get = []() { return rumble_get(3); },
+            .set = [](bool enable) { rumble_set(3, enable); },
         },
     },
 };

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -50,6 +50,7 @@ static Widget s_inputdisp_widgets[] = {
                 .label = "Color",
                 .choices = inputdisp_colors,
                 .num_choices = LEN(inputdisp_colors),
+                .flags = ChooseFlags::Pref,
                 .pref = pref::U8Pref::InputDispColor,
             },
     },

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -50,7 +50,6 @@ static Widget s_inputdisp_widgets[] = {
                 .label = "Color",
                 .choices = inputdisp_colors,
                 .num_choices = LEN(inputdisp_colors),
-                .flags = ChooseFlags::Pref,
                 .pref = pref::U8Pref::InputDispColor,
             },
     },

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -30,7 +30,6 @@ static Widget s_inputdisp_widgets[] = {
         .checkbox =
             {
                 .label = "Show Input Display",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::InputDisp,
             },
     },
@@ -39,7 +38,6 @@ static Widget s_inputdisp_widgets[] = {
         .checkbox =
             {
                 .label = "Use Center Location",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::InputDispCenterLocation,
             },
     },
@@ -50,7 +48,6 @@ static Widget s_inputdisp_widgets[] = {
                 .label = "Color",
                 .choices = inputdisp_colors,
                 .num_choices = LEN(inputdisp_colors),
-                .flags = ChooseFlags::Pref,
                 .pref = pref::U8Pref::InputDispColor,
             },
     },
@@ -59,7 +56,6 @@ static Widget s_inputdisp_widgets[] = {
         .checkbox =
             {
                 .label = "Notch Indicators",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::InputDispNotchIndicators,
             },
     },
@@ -68,7 +64,6 @@ static Widget s_inputdisp_widgets[] = {
         .checkbox =
             {
                 .label = "Raw Stick Inputs",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::InputDispRawStickInputs,
             },
     },
@@ -87,7 +82,6 @@ static Widget s_ball_color_widgets[] = {
                 .label = "Ball Color",
                 .choices = s_ball_colors,
                 .num_choices = LEN(s_ball_colors),
-                .flags = ChooseFlags::Pref,
                 .pref = pref::U8Pref::BallColor,
             },
     },
@@ -98,7 +92,6 @@ static Widget s_ball_color_widgets[] = {
                 .label = "Ape Color",
                 .choices = s_ball_colors,
                 .num_choices = LEN(s_ball_colors),
-                .flags = ChooseFlags::Pref,
                 .pref = pref::U8Pref::ApeColor,
             },
     },
@@ -118,7 +111,6 @@ static Widget s_il_battle_widgets[] = {
         .checkbox =
             {
                 .label = "IL Battle Display",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::IlBattleDisplay,
             },
     },
@@ -129,7 +121,6 @@ static Widget s_il_battle_widgets[] = {
                 .label = "Battle Length",
                 .choices = s_il_battle_lengths,
                 .num_choices = LEN(s_il_battle_lengths),
-                .flags = ChooseFlags::Pref,
                 .pref = pref::U8Pref::IlBattleLength,
             },
     },
@@ -138,7 +129,6 @@ static Widget s_il_battle_widgets[] = {
         .checkbox =
             {
                 .label = "Score Breakdown Info",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::IlBattleBreakdown,
             },
     },
@@ -146,45 +136,36 @@ static Widget s_il_battle_widgets[] = {
 };
 
 static Widget s_rumble_widgets[] = {
-    {.type = WidgetType::Checkbox,
-     .checkbox = {
-         .label = "Controller 1 Rumble",
-         .flags = CheckboxFlags::GetterSetter,
-         .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 0)); },
-         .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 0); },
-         .get_default = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 0)); },
-     }},
     {
-        .type = WidgetType::Checkbox,
-        .checkbox = {
+        .type = WidgetType::GetSetCheckbox,
+        .get_set_checkbox = {
+            .label = "Controller 1 Rumble",
+            .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 0)); },
+            .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 0); },
+        },
+    },
+    {
+        .type = WidgetType::GetSetCheckbox,
+        .get_set_checkbox = {
             .label = "Controller 2 Rumble",
-            .flags = CheckboxFlags::GetterSetter,
             .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 1)); },
             .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 1); },
-            .get_default =
-                []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 1)); },
         },
     },
     {
-        .type = WidgetType::Checkbox,
-        .checkbox = {
+        .type = WidgetType::GetSetCheckbox,
+        .get_set_checkbox = {
             .label = "Controller 3 Rumble",
-            .flags = CheckboxFlags::GetterSetter,
             .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 2)); },
             .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 2); },
-            .get_default =
-                []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 2)); },
         },
     },
     {
-        .type = WidgetType::Checkbox,
-        .checkbox = {
+        .type = WidgetType::GetSetCheckbox,
+        .get_set_checkbox = {
             .label = "Controller 4 Rumble",
-            .flags = CheckboxFlags::GetterSetter,
             .get = []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 3)); },
             .set = [](bool enable) { mkb::rumble_enabled_bitflag ^= (1 << 3); },
-            .get_default =
-                []() { return static_cast<bool>(mkb::rumble_enabled_bitflag & (1 << 3)); },
         },
     },
 };
@@ -232,7 +213,6 @@ static Widget s_cm_seg_widgets[] = {
              .label = "Character",
              .choices = chara_choices,
              .num_choices = LEN(chara_choices),
-             .flags = ChooseFlags::Pref,
              .pref = pref::U8Pref::CmChara,
          }},
     {.type = WidgetType::Separator},
@@ -381,7 +361,6 @@ static Widget s_timers_widgets[] = {
         .checkbox =
             {
                 .label = "RTA+Pause Timer",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::RtaPauseTimer,
             },
     },
@@ -390,7 +369,6 @@ static Widget s_timers_widgets[] = {
         .checkbox =
             {
                 .label = "Story Mode IW Timer",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::IwTimer,
             },
     },
@@ -399,7 +377,6 @@ static Widget s_timers_widgets[] = {
         .checkbox =
             {
                 .label = "CM Seg Timer",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::CmTimer,
             },
     },
@@ -486,7 +463,6 @@ static Widget s_sound_widgets[] = {
         .checkbox =
             {
                 .label = "Mute Background Music",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::MuteBgm,
             },
     },
@@ -499,7 +475,6 @@ static Widget s_sound_widgets[] = {
         .checkbox =
             {
                 .label = "Mute Timer Ding",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::MuteTimerDing,
             },
     },
@@ -554,7 +529,6 @@ static Widget s_unlock_widgets[] = {
         .checkbox =
             {
                 .label = "For Vanilla SMB2",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::UnlockVanilla,
             },
     },
@@ -563,7 +537,6 @@ static Widget s_unlock_widgets[] = {
         .checkbox =
             {
                 .label = "For Romhacks",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::UnlockRomhacks,
             },
     },
@@ -579,7 +552,6 @@ static Widget s_tools_widgets[] = {
         .checkbox =
             {
                 .label = "Savestates",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::Savestates,
             },
     },
@@ -588,7 +560,6 @@ static Widget s_tools_widgets[] = {
         .checkbox =
             {
                 .label = "Freeze Timer",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::FreezeTimer,
             },
     },
@@ -597,7 +568,6 @@ static Widget s_tools_widgets[] = {
         .checkbox =
             {
                 .label = "Freecam",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::Freecam,
             },
     },
@@ -606,7 +576,6 @@ static Widget s_tools_widgets[] = {
         .checkbox =
             {
                 .label = "Hide Background",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::HideBg,
             },
     },
@@ -624,7 +593,6 @@ static Widget s_tools_widgets[] = {
         .checkbox =
             {
                 .label = "Debug Mode",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::DebugMode,
             },
     },
@@ -636,7 +604,6 @@ static Widget s_il_mark_widgets[] = {
         .checkbox =
             {
                 .label = "Show in Practice Mode",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::IlMarkPractice,
             },
     },
@@ -645,7 +612,6 @@ static Widget s_il_mark_widgets[] = {
         .checkbox =
             {
                 .label = "Show in Story Mode",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::IlMarkStory,
             },
     },
@@ -654,7 +620,6 @@ static Widget s_il_mark_widgets[] = {
         .checkbox =
             {
                 .label = "Show in Challenge Mode",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::IlMarkChallenge,
             },
     },
@@ -686,7 +651,6 @@ static Widget s_displays_widgets[] = {
         .checkbox =
             {
                 .label = "9999 Banana Counter",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::BananaCounter9999,
             },
     },
@@ -698,7 +662,6 @@ static Widget s_gameplay_mods_widgets[] = {
         .checkbox =
             {
                 .label = "Jump Mod",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::JumpMod,
             },
     },
@@ -707,7 +670,6 @@ static Widget s_gameplay_mods_widgets[] = {
         .checkbox =
             {
                 .label = "Moon Gravity",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::Moon,
             },
     },
@@ -716,7 +678,6 @@ static Widget s_gameplay_mods_widgets[] = {
         .checkbox =
             {
                 .label = "Marathon Mode",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::Marathon,
             },
     },
@@ -725,7 +686,6 @@ static Widget s_gameplay_mods_widgets[] = {
         .checkbox =
             {
                 .label = "D-pad Controls",
-                .flags = CheckboxFlags::Pref,
                 .pref = pref::BoolPref::DpadControls,
             },
     },

--- a/src/systems/menu_defn.h
+++ b/src/systems/menu_defn.h
@@ -2,6 +2,8 @@
 
 #include "mkb/mkb.h"
 
+#include "pref.h"
+
 namespace menu_defn {
 
 enum class WidgetType {
@@ -32,11 +34,25 @@ struct HeaderWidget {
     const char* label;
 };
 
+namespace CheckboxFlags {
+enum {
+    Pref = 1 << 0,          // Use bool preference ID
+    GetterSetter = 1 << 1,  // Use manual getters/setters
+};
+}
+
 struct CheckboxWidget {
     const char* label;
-    // We can't use std::function due to destructors in unions stuff
-    bool (*get)();
-    void (*set)(bool);
+    u32 flags;
+    union {
+        pref::BoolPref pref;
+        struct {
+            // We can't use std::function due to destructors in unions stuff
+            bool (*get)();
+            void (*set)(bool);
+            bool (*get_default)();
+        };
+    };
 };
 
 struct MenuWidget {
@@ -53,12 +69,26 @@ struct FloatViewWidget {
     f32 (*get)();
 };
 
+namespace ChooseFlags {
+enum {
+    Pref,          // Use u8 preference ID
+    GetterSetter,  // Use manual getters/setters
+};
+}
+
 struct ChooseWidget {
     const char* label;
     const char** choices;
-    u32 num_choices;
-    u32 (*get)();
-    void (*set)(u32);
+    u16 num_choices;
+    u16 flags;
+    union {
+        pref::U8Pref pref;
+        struct {
+            u32 (*get)();
+            void (*set)(u32);
+            u32 (*get_default)();
+        };
+    };
 };
 
 namespace ButtonFlags {

--- a/src/systems/menu_defn.h
+++ b/src/systems/menu_defn.h
@@ -11,6 +11,7 @@ enum class WidgetType {
     ColoredText,
     Header,
     Checkbox,
+    GetSetCheckbox,
     Separator,
     Menu,
     FloatView,
@@ -43,16 +44,14 @@ enum {
 
 struct CheckboxWidget {
     const char* label;
-    u32 flags;
-    union {
-        pref::BoolPref pref;
-        struct {
-            // We can't use std::function due to destructors in unions stuff
-            bool (*get)();
-            void (*set)(bool);
-            bool (*get_default)();
-        };
-    };
+    pref::BoolPref pref;
+};
+
+// For the rare cases a checkbox doesn't correspond to a preference
+struct GetSetCheckboxWidget {
+    const char *label;
+    bool (*get)();
+    void (*set)(bool);
 };
 
 struct MenuWidget {
@@ -80,15 +79,7 @@ struct ChooseWidget {
     const char* label;
     const char** choices;
     u16 num_choices;
-    u16 flags;
-    union {
-        pref::U8Pref pref;
-        struct {
-            u8 (*get)();
-            void (*set)(u8);
-            u8 (*get_default)();
-        };
-    };
+    pref::U8Pref pref;
 };
 
 namespace ButtonFlags {
@@ -115,6 +106,7 @@ struct Widget {
         ColoredTextWidget colored_text;
         HeaderWidget header;
         CheckboxWidget checkbox;
+        GetSetCheckboxWidget get_set_checkbox;
         MenuWidget menu;
         FloatViewWidget float_view;
         ChooseWidget choose;

--- a/src/systems/menu_defn.h
+++ b/src/systems/menu_defn.h
@@ -19,6 +19,21 @@ enum class WidgetType {
     Custom,
 };
 
+// Something we can get/set/get default
+// I'm probably going to regret this...
+template <typename ValueType, typename PrefType>
+class PrefLike {
+ public:
+    PrefLike(ValueType (*get)(), void (*set)(ValueType), ValueType (*get_default)()) {}
+    PrefLike(PrefType pref);
+
+ private:
+    bool is_pref;
+    union {
+        PrefType pref;
+    }
+};
+
 struct TextWidget {
     const char* label;            // For static text
     const char* (*label_func)();  // For dynamic text
@@ -69,26 +84,11 @@ struct FloatViewWidget {
     f32 (*get)();
 };
 
-namespace ChooseFlags {
-enum {
-    Pref,          // Use u8 preference ID
-    GetterSetter,  // Use manual getters/setters
-};
-}
-
 struct ChooseWidget {
     const char* label;
     const char** choices;
     u16 num_choices;
-    u16 flags;
-    union {
-        pref::U8Pref pref;
-        struct {
-            u8 (*get)();
-            void (*set)(u8);
-            u8 (*get_default)();
-        };
-    };
+    pref::U8Pref pref;
 };
 
 namespace ButtonFlags {

--- a/src/systems/menu_defn.h
+++ b/src/systems/menu_defn.h
@@ -19,21 +19,6 @@ enum class WidgetType {
     Custom,
 };
 
-// Something we can get/set/get default
-// I'm probably going to regret this...
-template <typename ValueType, typename PrefType>
-class PrefLike {
- public:
-    PrefLike(ValueType (*get)(), void (*set)(ValueType), ValueType (*get_default)()) {}
-    PrefLike(PrefType pref);
-
- private:
-    bool is_pref;
-    union {
-        PrefType pref;
-    }
-};
-
 struct TextWidget {
     const char* label;            // For static text
     const char* (*label_func)();  // For dynamic text
@@ -84,11 +69,26 @@ struct FloatViewWidget {
     f32 (*get)();
 };
 
+namespace ChooseFlags {
+enum {
+    Pref,          // Use u8 preference ID
+    GetterSetter,  // Use manual getters/setters
+};
+}
+
 struct ChooseWidget {
     const char* label;
     const char** choices;
     u16 num_choices;
-    pref::U8Pref pref;
+    u16 flags;
+    union {
+        pref::U8Pref pref;
+        struct {
+            u8 (*get)();
+            void (*set)(u8);
+            u8 (*get_default)();
+        };
+    };
 };
 
 namespace ButtonFlags {

--- a/src/systems/menu_defn.h
+++ b/src/systems/menu_defn.h
@@ -35,13 +35,6 @@ struct HeaderWidget {
     const char* label;
 };
 
-namespace CheckboxFlags {
-enum {
-    Pref = 1 << 0,          // Use bool preference ID
-    GetterSetter = 1 << 1,  // Use manual getters/setters
-};
-}
-
 struct CheckboxWidget {
     const char* label;
     pref::BoolPref pref;
@@ -67,13 +60,6 @@ struct FloatViewWidget {
     const char* label;
     f32 (*get)();
 };
-
-namespace ChooseFlags {
-enum {
-    Pref,          // Use u8 preference ID
-    GetterSetter,  // Use manual getters/setters
-};
-}
 
 struct ChooseWidget {
     const char* label;

--- a/src/systems/menu_defn.h
+++ b/src/systems/menu_defn.h
@@ -84,9 +84,9 @@ struct ChooseWidget {
     union {
         pref::U8Pref pref;
         struct {
-            u32 (*get)();
-            void (*set)(u32);
-            u32 (*get_default)();
+            u8 (*get)();
+            void (*set)(u8);
+            u8 (*get_default)();
         };
     };
 };

--- a/src/systems/menu_impl.cpp
+++ b/src/systems/menu_impl.cpp
@@ -46,6 +46,11 @@ static void pop_menu() {
     pad::reset_dir_repeat();
 }
 
+static bool is_widget_selectable(WidgetType type) {
+    return type == WidgetType::Checkbox || type == WidgetType::GetSetCheckbox ||
+           type == WidgetType::Menu || type == WidgetType::Choose || type == WidgetType::Button;
+}
+
 static Widget* get_selected_widget() {
     MenuWidget* menu = s_menu_stack[s_menu_stack_ptr];
     s32 sel = menu->selected_idx;
@@ -53,8 +58,7 @@ static Widget* get_selected_widget() {
     s32 selectable = -1;
     for (u32 i = 0; i < menu->num_widgets; i++) {
         Widget* child = &menu->widgets[i];
-        if (child->type == WidgetType::Checkbox || child->type == WidgetType::Menu ||
-            child->type == WidgetType::Choose || child->type == WidgetType::Button) {
+        if (is_widget_selectable(child->type)) {
             selectable++;
             if (selectable == sel) return child;
         }
@@ -67,8 +71,7 @@ static u32 get_menu_selectable_widget_count(MenuWidget* menu) {
     u32 selectable = 0;
     for (u32 i = 0; i < menu->num_widgets; i++) {
         Widget* child = &menu->widgets[i];
-        if (child->type == WidgetType::Checkbox || child->type == WidgetType::Menu ||
-            child->type == WidgetType::Choose || child->type == WidgetType::Button) {
+        if (is_widget_selectable(child->type)) {
             selectable++;
         }
     }

--- a/src/systems/menu_impl.cpp
+++ b/src/systems/menu_impl.cpp
@@ -227,18 +227,29 @@ void draw_menu_widget(MenuWidget* menu) {
                 y += LINE_HEIGHT;
                 break;
             }
-            case WidgetType::Checkbox: {
+            case WidgetType::Checkbox:
+            case WidgetType::GetSetCheckbox: {
+                const char* label = nullptr;
+                bool value = false;
+                if (widget.type == WidgetType::Checkbox) {
+                    label = widget.checkbox.label;
+                    value = pref::get(widget.checkbox.pref);
+                } else {
+                    label = widget.get_set_checkbox.label;
+                    value = widget.get_set_checkbox.get();
+                }
+
                 if (menu->selected_idx == selectable_idx) {
                     draw_selectable_highlight(y);
                 }
                 draw::debug_text(
                     MARGIN + PAD, y,
                     menu->selected_idx == selectable_idx ? lerped_color : UNFOCUSED_COLOR, "  %s",
-                    widget.checkbox.label);
+                    label);
                 draw::debug_text(
                     MARGIN + PAD, y,
                     menu->selected_idx == selectable_idx ? lerped_color : UNFOCUSED_COLOR,
-                    "                         %s", pref::get(widget.checkbox.pref) ? "On" : "Off");
+                    "                         %s", value ? "On" : "Off");
 
                 y += LINE_HEIGHT;
                 selectable_idx++;

--- a/src/systems/pref.cpp
+++ b/src/systems/pref.cpp
@@ -47,62 +47,7 @@ enum class PrefId : u16 {
     UnlockRomhacks = 31,
 };
 
-// Bit index into Pref struct (not ID of preference itself as stored in memcard file)
-enum class BoolPref {
-    Savestates,
-    InputDisp,
-    InputDispCenterLocation,
-    RtaPauseTimer,
-    InputDispNotchIndicators,
-    IwTimer,
-    CmTimer,
-    JumpMod,
-    BananaCounter9999,
-    DpadControls,
-    DebugMode,
-    FreezeTimer,
-    MuteBgm,
-    MuteTimerDing,
-    InputDispRawStickInputs,
-    Freecam,
-    Marathon,
-    Moon,
-    IlBattleDisplay,
-    IlBattleBreakdown,
-    IlMarkPractice,
-    IlMarkStory,
-    IlMarkChallenge,
-    HideBg,
-    UnlockVanilla,
-    UnlockRomhacks,
-};
-
-struct Pref {
-    u8 bool_prefs[8];
-    u8 cm_chara;
-    u8 input_disp_color;
-    u8 ball_color;
-    u8 ape_color;
-    u8 il_battle_length;
-} s_pref;
-
-struct FileHeader {
-    char magic[4];  // "APMP"
-    u16 semver_major;
-    u16 semver_minor;
-    u16 semver_patch;
-    u16 num_prefs;
-} __attribute__((__packed__));
-
-struct IdEntry {
-    u16 id;
-    u16 data;  // Either the preference value itself (if <= 2 bytes), or offset into buffer
-               // prefs, etc
-} __attribute((__packed__));
-
-/*
- * Verbatim list of preference IDs we iterate over when writing savefile back out
- */
+// Verbatim list of preference IDs we iterate over when writing savefile back out
 static const PrefId s_pref_ids[] = {
     PrefId::Savestates,
     PrefId::InputDisp,
@@ -135,30 +80,6 @@ static const PrefId s_pref_ids[] = {
     PrefId::UnlockVanilla,
     PrefId::UnlockRomhacks,
 };
-
-static u8 s_card_buf[sizeof(FileHeader) + LEN(s_pref_ids) * sizeof(IdEntry)]
-    __attribute__((__aligned__(32)));  // CARD API requires 32-byte alignment
-
-static inline u16 validate_bool_pref(BoolPref bp) {
-    u16 bpi = static_cast<u16>(bp);
-    MOD_ASSERT(static_cast<u16>(bpi / 8) < LEN(s_pref.bool_prefs));  // Out of room for bool
-                                                                     // prefs
-    return bpi;
-}
-
-static bool get_bool_pref(BoolPref bp) {
-    u16 bpi = validate_bool_pref(bp);
-    return s_pref.bool_prefs[bpi / 8] & (1 << (bpi % 8));
-}
-
-static void set_bool_pref(BoolPref bp, bool value) {
-    u16 bpi = validate_bool_pref(bp);
-    if (value) {
-        s_pref.bool_prefs[bpi / 8] |= (1 << (bpi % 8));
-    } else {
-        s_pref.bool_prefs[bpi / 8] &= ~(1 << (bpi % 8));
-    }
-}
 
 static std::optional<BoolPref> pref_id_to_bool_pref(PrefId id) {
     switch (id) {
@@ -219,22 +140,75 @@ static std::optional<BoolPref> pref_id_to_bool_pref(PrefId id) {
     }
 }
 
-static u8* pref_id_to_u8(PrefId id, Pref& pref) {
+static std::optional<U8Pref> pref_id_to_u8_pref(PrefId id) {
     switch (id) {
         case PrefId::CmChara:
-            return &pref.cm_chara;
+            return U8Pref::CmChara;
         case PrefId::InputDispColor:
-            return &pref.input_disp_color;
+            return U8Pref::InputDispColor;
         case PrefId::BallColor:
-            return &pref.ball_color;
+            return U8Pref::BallColor;
         case PrefId::ApeColor:
-            return &pref.ape_color;
+            return U8Pref::ApeColor;
         case PrefId::IlBattleLength:
-            return &pref.il_battle_length;
+            return U8Pref::IlBattleLength;
         default:
-            return nullptr;
+            return {};
     }
 }
+
+struct Pref {
+    u8 bool_prefs[8];
+    u8 u8_prefs[8];
+} s_pref;
+
+struct FileHeader {
+    char magic[4];  // "APMP"
+    u16 semver_major;
+    u16 semver_minor;
+    u16 semver_patch;
+    u16 num_prefs;
+} __attribute__((__packed__));
+
+struct IdEntry {
+    u16 id;
+    u16 data;  // Either the preference value itself (if <= 2 bytes), or offset into buffer
+               // prefs, etc
+} __attribute((__packed__));
+
+static u8 s_card_buf[sizeof(FileHeader) + LEN(s_pref_ids) * sizeof(IdEntry)]
+    __attribute__((__aligned__(32)));  // CARD API requires 32-byte alignment
+
+static inline u16 validate_bool_pref(BoolPref bp) {
+    u16 bpi = static_cast<u16>(bp);
+    MOD_ASSERT(static_cast<u16>(bpi / 8) < LEN(s_pref.bool_prefs));  // Out of room for bool
+                                                                     // prefs
+    return bpi;
+}
+
+static bool get_bool_pref(BoolPref bp) {
+    u16 bpi = validate_bool_pref(bp);
+    return s_pref.bool_prefs[bpi / 8] & (1 << (bpi % 8));
+}
+
+static void set_bool_pref(BoolPref bp, bool value) {
+    u16 bpi = validate_bool_pref(bp);
+    if (value) {
+        s_pref.bool_prefs[bpi / 8] |= (1 << (bpi % 8));
+    } else {
+        s_pref.bool_prefs[bpi / 8] &= ~(1 << (bpi % 8));
+    }
+}
+
+static u32 validate_u8_pref(U8Pref pref) {
+    u32 idx = static_cast<u32>(pref);
+    MOD_ASSERT(idx < LEN(s_pref.u8_prefs));
+    return idx;
+}
+
+static u8 get_u8_pref(U8Pref pref) { return s_pref.u8_prefs[validate_u8_pref(pref)]; }
+
+static void set_u8_pref(U8Pref pref, u8 value) { s_pref.u8_prefs[validate_u8_pref(pref)] = value; }
 
 static void card_buf_to_pref_struct(void* card_buf) {
     FileHeader* header = static_cast<FileHeader*>(card_buf);
@@ -248,17 +222,16 @@ static void card_buf_to_pref_struct(void* card_buf) {
         u16 pref_data = entry_list[i].data;
 
         // If it's a boolean preference, copy it from the memcard file
-        std::optional<BoolPref> bool_pref_idx = pref_id_to_bool_pref(id);
-        if (bool_pref_idx.has_value()) {
-            set_bool_pref(bool_pref_idx.value(), pref_data);
+        std::optional<BoolPref> bool_pref = pref_id_to_bool_pref(id);
+        if (bool_pref.has_value()) {
+            set_bool_pref(bool_pref.value(), pref_data);
             continue;
         }
 
         // For u8 preferences, copy them to struct fields directly
-        u8* u8_pref = pref_id_to_u8(id, s_pref);
-        if (u8_pref != nullptr) {
-            // File data offset is in bytes
-            *u8_pref = static_cast<u8>(pref_data);
+        std::optional<U8Pref> u8_pref = pref_id_to_u8_pref(id);
+        if (u8_pref.has_value()) {
+            set_u8_pref(u8_pref.value(), static_cast<u8>(pref_data));
             continue;
         }
 
@@ -296,16 +269,16 @@ static void pref_struct_to_card_buf() {
         entry_list[i].id = static_cast<u16>(id);
 
         // Write out boolean preference if this is a boolean
-        std::optional<BoolPref> bool_pref_idx = pref_id_to_bool_pref(id);
-        if (bool_pref_idx.has_value()) {
-            entry_list[i].data = get_bool_pref(bool_pref_idx.value());
+        std::optional<BoolPref> bool_pref = pref_id_to_bool_pref(id);
+        if (bool_pref.has_value()) {
+            entry_list[i].data = get_bool_pref(bool_pref.value());
             continue;
         }
 
         // Write out u8 preference if this is a u8
-        const u8* u8_pref = pref_id_to_u8(id, s_pref);
-        if (u8_pref != nullptr) {
-            entry_list[i].data = *u8_pref;
+        std::optional<U8Pref> u8_pref = pref_id_to_u8_pref(id);
+        if (u8_pref.has_value()) {
+            entry_list[i].data = get_u8_pref(u8_pref.value());
             continue;
         }
 
@@ -341,77 +314,5 @@ void save() {
         }
     });
 }
-
-u8 get_cm_chara() { return s_pref.cm_chara; }
-void set_cm_chara(u8 idx) { s_pref.cm_chara = idx; }
-
-bool get_savestates() { return get_bool_pref(BoolPref::Savestates); }
-void set_savestates(bool on) { set_bool_pref(BoolPref::Savestates, on); }
-
-bool get_input_disp() { return get_bool_pref(BoolPref::InputDisp); }
-void set_input_disp(bool on) { set_bool_pref(BoolPref::InputDisp, on); }
-bool get_input_disp_center_location() { return get_bool_pref(BoolPref::InputDispCenterLocation); }
-void set_input_disp_center_location(bool on) {
-    set_bool_pref(BoolPref::InputDispCenterLocation, on);
-};
-u8 get_input_disp_color() { return s_pref.input_disp_color; }
-void set_input_disp_color(u8 idx) { s_pref.input_disp_color = idx; }
-u8 get_ball_color() { return s_pref.ball_color; }
-void set_ball_color(u8 idx) { s_pref.ball_color = idx; }
-u8 get_ape_color() { return s_pref.ape_color; }
-void set_ape_color(u8 idx) { s_pref.ape_color = idx; }
-u8 get_il_battle_length() { return s_pref.il_battle_length; }
-void set_il_battle_length(u8 idx) { s_pref.il_battle_length = idx; }
-bool get_input_disp_notch_indicators() { return get_bool_pref(BoolPref::InputDispNotchIndicators); }
-void set_input_disp_notch_indicators(bool on) {
-    set_bool_pref(BoolPref::InputDispNotchIndicators, on);
-}
-bool get_input_disp_raw_stick_inputs() { return get_bool_pref(BoolPref::InputDispRawStickInputs); }
-void set_input_disp_raw_stick_inputs(bool on) {
-    set_bool_pref(BoolPref::InputDispRawStickInputs, on);
-}
-bool get_marathon() { return get_bool_pref(BoolPref::Marathon); }
-void set_marathon(bool on) { set_bool_pref(BoolPref::Marathon, on); }
-bool get_moon() { return get_bool_pref(BoolPref::Moon); }
-void set_moon(bool on) { set_bool_pref(BoolPref::Moon, on); }
-bool get_il_battle_display() { return get_bool_pref(BoolPref::IlBattleDisplay); }
-void set_il_battle_display(bool on) { set_bool_pref(BoolPref::IlBattleDisplay, on); }
-bool get_il_battle_breakdown() { return get_bool_pref(BoolPref::IlBattleBreakdown); }
-void set_il_battle_breakdown(bool on) { set_bool_pref(BoolPref::IlBattleBreakdown, on); }
-bool get_rta_pause_timer() { return get_bool_pref(BoolPref::RtaPauseTimer); }
-void set_rta_pause_timer(bool on) { set_bool_pref(BoolPref::RtaPauseTimer, on); }
-bool get_iw_timer() { return get_bool_pref(BoolPref::IwTimer); }
-void set_iw_timer(bool on) { set_bool_pref(BoolPref::IwTimer, on); }
-bool get_cm_timer() { return get_bool_pref(BoolPref::CmTimer); }
-void set_cm_timer(bool on) { set_bool_pref(BoolPref::CmTimer, on); }
-bool get_il_mark_practice() { return get_bool_pref(BoolPref::IlMarkPractice); }
-void set_il_mark_practice(bool on) { set_bool_pref(BoolPref::IlMarkPractice, on); }
-bool get_il_mark_story() { return get_bool_pref(BoolPref::IlMarkStory); }
-void set_il_mark_story(bool on) { set_bool_pref(BoolPref::IlMarkStory, on); }
-bool get_il_mark_challenge() { return get_bool_pref(BoolPref::IlMarkChallenge); }
-void set_il_mark_challenge(bool on) { set_bool_pref(BoolPref::IlMarkChallenge, on); }
-
-bool get_jump_mod() { return get_bool_pref(BoolPref::JumpMod); }
-void set_jump_mod(bool on) { set_bool_pref(BoolPref::JumpMod, on); }
-bool get_9999_banana_counter() { return get_bool_pref(BoolPref::BananaCounter9999); }
-void set_9999_banana_counter(bool on) { set_bool_pref(BoolPref::BananaCounter9999, on); }
-bool get_dpad_controls() { return get_bool_pref(BoolPref::DpadControls); }
-void set_dpad_controls(bool on) { set_bool_pref(BoolPref::DpadControls, on); }
-bool get_debug_mode() { return get_bool_pref(BoolPref::DebugMode); }
-void set_debug_mode(bool on) { set_bool_pref(BoolPref::DebugMode, on); }
-bool get_freeze_timer() { return get_bool_pref(BoolPref::FreezeTimer); }
-void set_freeze_timer(bool on) { set_bool_pref(BoolPref::FreezeTimer, on); }
-bool get_mute_bgm() { return get_bool_pref(BoolPref::MuteBgm); }
-void set_mute_bgm(bool on) { set_bool_pref(BoolPref::MuteBgm, on); }
-bool get_mute_timer_ding() { return get_bool_pref(BoolPref::MuteTimerDing); }
-void set_mute_timer_ding(bool on) { set_bool_pref(BoolPref::MuteTimerDing, on); }
-bool get_freecam() { return get_bool_pref(BoolPref::Freecam); }
-void set_freecam(bool on) { return set_bool_pref(BoolPref::Freecam, on); }
-bool get_hide_bg() { return get_bool_pref(BoolPref::HideBg); }
-void set_hide_bg(bool on) { set_bool_pref(BoolPref::HideBg, on); }
-bool get_unlock_vanilla() { return get_bool_pref(BoolPref::UnlockVanilla); }
-void set_unlock_vanilla(bool on) { set_bool_pref(BoolPref::UnlockVanilla, on); }
-bool get_unlock_romhacks() { return get_bool_pref(BoolPref::UnlockRomhacks); }
-void set_unlock_romhacks(bool on) { set_bool_pref(BoolPref::UnlockRomhacks, on); }
 
 }  // namespace pref

--- a/src/systems/pref.h
+++ b/src/systems/pref.h
@@ -1,14 +1,11 @@
 #pragma once
 
-/*
- * Mod user preferences, backed by memory card save file
- */
+// Mod user preferences, backed by memory card save file
 
 #include "mkb/mkb.h"
 
 namespace pref {
 
-// Bit index into Pref struct (not ID of preference itself as stored in memcard file)
 enum class BoolPref {
     Savestates,
     InputDisp,

--- a/src/systems/pref.h
+++ b/src/systems/pref.h
@@ -1,3 +1,5 @@
+#pragma once
+
 /*
  * Mod user preferences, backed by memory card save file
  */

--- a/src/systems/pref.h
+++ b/src/systems/pref.h
@@ -6,74 +6,50 @@
 
 namespace pref {
 
+// Bit index into Pref struct (not ID of preference itself as stored in memcard file)
+enum class BoolPref {
+    Savestates,
+    InputDisp,
+    InputDispCenterLocation,
+    RtaPauseTimer,
+    InputDispNotchIndicators,
+    IwTimer,
+    CmTimer,
+    JumpMod,
+    BananaCounter9999,
+    DpadControls,
+    DebugMode,
+    FreezeTimer,
+    MuteBgm,
+    MuteTimerDing,
+    InputDispRawStickInputs,
+    Freecam,
+    Marathon,
+    Moon,
+    IlBattleDisplay,
+    IlBattleBreakdown,
+    IlMarkPractice,
+    IlMarkStory,
+    IlMarkChallenge,
+    HideBg,
+    UnlockVanilla,
+    UnlockRomhacks,
+};
+
+enum class U8Pref {
+    CmChara,
+    InputDispColor,
+    BallColor,
+    ApeColor,
+    IlBattleLength,
+};
+
 void init();
 void save();
 
-u8 get_cm_chara();
-void set_cm_chara(u8 idx);
-
-bool get_savestates();
-void set_savestates(bool on);
-
-bool get_input_disp();
-void set_input_disp(bool on);
-bool get_input_disp_center_location();
-void set_input_disp_center_location(bool on);
-u8 get_input_disp_color();
-void set_input_disp_color(u8 idx);
-u8 get_ball_color();
-void set_ball_color(u8 idx);
-u8 get_ape_color();
-void set_ape_color(u8 idx);
-u8 get_il_battle_length();
-void set_il_battle_length(u8 idx);
-bool get_input_disp_notch_indicators();
-void set_input_disp_notch_indicators(bool on);
-bool get_input_disp_raw_stick_inputs();
-void set_input_disp_raw_stick_inputs(bool on);
-bool get_marathon();
-void set_marathon(bool on);
-bool get_moon();
-void set_moon(bool on);;
-bool get_il_battle_display();
-void set_il_battle_display(bool on);
-bool get_il_battle_breakdown();
-void set_il_battle_breakdown(bool on);
-bool get_il_mark_practice();
-void set_il_mark_practice(bool on);
-bool get_il_mark_story();
-void set_il_mark_story(bool on);
-bool get_il_mark_challenge();
-void set_il_mark_challenge(bool on);
-
-bool get_rta_pause_timer();
-void set_rta_pause_timer(bool on);
-bool get_iw_timer();
-void set_iw_timer(bool on);
-bool get_cm_timer();
-void set_cm_timer(bool on);
-
-bool get_jump_mod();
-void set_jump_mod(bool on);
-bool get_9999_banana_counter();
-void set_9999_banana_counter(bool on);
-bool get_dpad_controls();
-void set_dpad_controls(bool on);
-bool get_debug_mode();
-void set_debug_mode(bool on);
-bool get_freeze_timer();
-void set_freeze_timer(bool on);
-bool get_mute_bgm();
-void set_mute_bgm(bool on);
-bool get_mute_timer_ding();
-void set_mute_timer_ding(bool on);
-bool get_freecam();
-void set_freecam(bool on);
-bool get_hide_bg();
-void set_hide_bg(bool on);
-bool get_unlock_vanilla();
-void set_unlock_vanilla(bool on);
-bool get_unlock_romhacks();
-void set_unlock_romhacks(bool on);
+bool get(BoolPref bool_pref);
+u8 get(U8Pref u8_pref);
+void set(BoolPref bool_pref, bool value);
+void set(U8Pref u8_pref, u8 value);
 
 }  // namespace pref

--- a/src/systems/pref.h
+++ b/src/systems/pref.h
@@ -53,5 +53,7 @@ bool get(BoolPref bool_pref);
 u8 get(U8Pref u8_pref);
 void set(BoolPref bool_pref, bool value);
 void set(U8Pref u8_pref, u8 value);
+bool get_default(BoolPref bool_pref);
+u8 get_default(U8Pref u8_pref);
 
 }  // namespace pref

--- a/src/utils/libsavest.cpp
+++ b/src/utils/libsavest.cpp
@@ -29,7 +29,7 @@ void init() {
     // This way the minimap is unaffected when loading savestates after goal/fallout
     patch::hook_function(
         s_set_minimap_mode_tramp, mkb::set_minimap_mode, [](mkb::MinimapMode mode) {
-            if (!pref::get_savestates() ||
+            if (!pref::get(pref::BoolPref::Savestates) ||
                 !(mkb::main_mode == mkb::MD_GAME && mkb::main_game_mode == mkb::PRACTICE_MODE &&
                   mode == mkb::MINIMAP_SHRINK)) {
                 s_set_minimap_mode_tramp.dest(mode);


### PR DESCRIPTION
Reference preferences by per-type preference IDs instead of getters/setters for each preference. This reduces boilerplate and prevents additional boilerplate for reset-to-default functionality in widgets (which I also added in this PR).

There was only one instance where a widget needed raw getters/setters instead of being linked to a preference, and it seemed cleanest to just use a new `GetSetCheckboxWidget` to handle this special case.