### PR TITLE
Timer Fix & Menu Cleanup

### DIFF
--- a/src/mods/fallout.cpp
+++ b/src/mods/fallout.cpp
@@ -68,7 +68,7 @@ void init() {
 
     patch::hook_function(s_load_stagedef_tramp, mkb::load_stagedef, [](u32 stage_id) {
         // Set the current default values before loading the stagedef
-        *reinterpret_cast<u32*>(0x80297548) = s_timeover_condition;
+        patch::write_word(reinterpret_cast<u32*>(0x80297548), s_timeover_condition);
         patch::write_word(reinterpret_cast<u32*>(0x80297534), s_timer_increment);
         s_load_stagedef_tramp.dest(stage_id);
         // Stardust's custom code sets the timers after loading the stagedef, this will run
@@ -91,7 +91,7 @@ void freeze_timer() {
         case TimerType::Default: {
             if (pref::did_change(pref::U8Pref::TimerType) || s_toggled_freecam) {
                 // time over at 0 frames
-                *reinterpret_cast<u32*>(0x80297548) = s_timeover_condition;
+                patch::write_word(reinterpret_cast<u32*>(0x80297548), s_timeover_condition);
                 // add -1 to timer each frame
                 patch::write_word(reinterpret_cast<u32*>(0x80297534), s_timer_increment);
                 s_toggled_freecam = false;
@@ -100,14 +100,14 @@ void freeze_timer() {
         }
         case TimerType::FreezeInstantly: {
             // time over at -60 frames (for leniency when switching modes)
-            *reinterpret_cast<u32*>(0x80297548) = 0x2c00ffa0;
+            patch::write_word(reinterpret_cast<u32*>(0x80297548), 0x2c00ffa0);
             // add 0 to timer each frame (timer doesnt move)
             patch::write_word(reinterpret_cast<u32*>(0x80297534), 0x38030000);
             break;
         }
         case TimerType::FreezeAtZero: {
             // time over at -60 frames (so timer is able to stop at 0.00)
-            *reinterpret_cast<u32*>(0x80297548) = 0x2c00ffa0;
+            patch::write_word(reinterpret_cast<u32*>(0x80297548), 0x2c00ffa0);
 
             if (mkb::mode_info.stage_time_frames_remaining <= 0) {
                 // when timer hits 0, add 0 to timer each frame
@@ -123,7 +123,7 @@ void freeze_timer() {
                 mkb::mode_info.stage_time_frames_remaining = 0;
             }
             // time over at -60 frames (so timer is able to stop at 0.00)
-            *reinterpret_cast<u32*>(0x80297548) = 0x2c00ffa0;
+            patch::write_word(reinterpret_cast<u32*>(0x80297548), 0x2c00ffa0);
 
             // getting close to signed integer overflow, freeze timer to prevent time-over
             if (mkb::mode_info.stage_time_frames_remaining >= 32400) {

--- a/src/systems/main.cpp
+++ b/src/systems/main.cpp
@@ -119,11 +119,11 @@ void init() {
         binds::tick();
         cardio::tick();
         unlock::tick();
-        fallout::tick();
         physics::tick();
         iw::tick();
         savest_ui::tick();
         menu_impl::tick();
+        fallout::tick();
         jump::tick();
         inputdisp::tick();
         gotostory::tick();

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -826,7 +826,7 @@ static Widget s_help_widgets[] = {
     },
     {
         .type = WidgetType::Menu,
-        .menu = {"Jump Mod", s_jump_help_widgets, LEN(s_jump_help_widgets)},
+        .menu = {"Jump-Mod", s_jump_help_widgets, LEN(s_jump_help_widgets)},
     },
     {
         .type = WidgetType::Menu,
@@ -1601,7 +1601,7 @@ static Widget s_jump_widgets[] = {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
-                .label = "Jump Mod",
+                .label = "Jump-Mod",
                 .pref = pref::BoolPref::JumpMod,
             },
     },
@@ -1658,7 +1658,7 @@ static Widget s_gameplay_mods_widgets[] = {
         .type = WidgetType::Menu,
         .menu =
             {
-                .label = "Jump Mod",
+                .label = "Jump-Mod",
                 .widgets = s_jump_widgets,
                 .num_widgets = LEN(s_jump_widgets),
             },

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -954,11 +954,6 @@ static Widget s_freecam_widgets[] = {
                 .can_unbind = true,
             },
     },
-    {
-        .type = WidgetType::Text,
-        .text = {"  Freecam uses the controller in Port 1"},
-
-    },
     {.type = WidgetType::Separator},
     {
         .type = WidgetType::Header,

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -16,8 +16,8 @@
 #include "utils/draw.h"
 #include "utils/macro_utils.h"
 
-// TODO update buttons with close menu flag
-// TODO let buttons have null push()
+// TODO: update buttons with close menu flag
+// TODO: let buttons have null push()
 
 namespace menu_defn {
 
@@ -404,7 +404,7 @@ static Widget s_il_battle_subwidgets[] = {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
-                .label = "Old Buzzer Message",
+                .label = "Buzzer Message",
                 .pref = pref::BoolPref::IlBattleBuzzerOld,
             },
     },
@@ -696,7 +696,7 @@ static Widget s_cm_seg_widgets[] = {
     {.type = WidgetType::Separator},
     {
         .type = WidgetType::Text,
-        .text = {"Segments may crash in some romhacks"},
+        .text = {"  Segments may crash in some romhacks"},
     },
 };
 
@@ -768,7 +768,7 @@ static Widget s_savestates_help_widgets[] = {
     {.type = WidgetType::Text, .text = {"  X          \x1c Create savestate"}},
     {.type = WidgetType::Text, .text = {"  Y          \x1c Load savestate"}},
     {.type = WidgetType::Text, .text = {"  C-Stick    \x1c Change savestate slot"}},
-    // TODO replace this feature with a better one that works in-menu
+    // TODO: replace this feature with a better one that works in-menu
     {.type = WidgetType::Text, .text = {"  L+X or R+X \x1c Frame advance"}},
     {.type = WidgetType::Text, .text = {"  L+C or R+C \x1c Browse savestates"}},
 };
@@ -931,16 +931,38 @@ static Widget s_unlock_widgets[] = {
     },
 };
 
-static Widget s_freecam_subwidgets[] = {
+static Widget s_freecam_widgets[] = {
     {
-        .type = WidgetType::IntEdit,
-        .int_edit =
+        .type = WidgetType::Header,
+        .header = {"Freecam Toggle"},
+    },
+    {
+        .type = WidgetType::Checkbox,
+        .checkbox =
             {
-                .label = "Turbo Speed Factor",
-                .pref = pref::U8Pref::FreecamSpeedMult,
-                .min = freecam::TURBO_SPEED_MIN,
-                .max = freecam::TURBO_SPEED_MAX,
+                .label = "Freecam",
+                .pref = pref::BoolPref::Freecam,
             },
+    },
+    {
+        .type = WidgetType::InputSelect,
+        .input_select =
+            {
+                .label = "Toggle Bind",
+                .pref = pref::U8Pref::FreecamToggleBind,
+                .required_chord = false,
+                .can_unbind = true,
+            },
+    },
+    {
+        .type = WidgetType::Text,
+        .text = {"  Freecam uses the controller in Port 1"},
+
+    },
+    {.type = WidgetType::Separator},
+    {
+        .type = WidgetType::Header,
+        .header = {"Configuration"},
     },
     {
         .type = WidgetType::Checkbox,
@@ -959,6 +981,16 @@ static Widget s_freecam_subwidgets[] = {
             },
     },
     {
+        .type = WidgetType::IntEdit,
+        .int_edit =
+            {
+                .label = "Turbo Speed Factor",
+                .pref = pref::U8Pref::FreecamSpeedMult,
+                .min = freecam::TURBO_SPEED_MIN,
+                .max = freecam::TURBO_SPEED_MAX,
+            },
+    },
+    {
         .type = WidgetType::Checkbox,
         .checkbox =
             {
@@ -972,36 +1004,6 @@ static Widget s_freecam_subwidgets[] = {
             {
                 .label = "Hide HUD",
                 .pref = pref::BoolPref::FreecamHideHud,
-            },
-    },
-};
-
-static Widget s_freecam_widgets[] = {
-    {
-        .type = WidgetType::Checkbox,
-        .checkbox =
-            {
-                .label = "Freecam",
-                .pref = pref::BoolPref::Freecam,
-            },
-    },
-    {
-        .type = WidgetType::InputSelect,
-        .input_select =
-            {
-                .label = "Freecam Toggle Bind",
-                .pref = pref::U8Pref::FreecamToggleBind,
-                .required_chord = false,
-                .can_unbind = true,
-            },
-    },
-    {
-        .type = WidgetType::HideableGroupWidget,
-        .hideable_group =
-            {
-                .widgets = s_freecam_subwidgets,
-                .num_widgets = LEN(s_freecam_subwidgets),
-                .show_if = [] { return pref::get(pref::BoolPref::Freecam); },
             },
     },
 };
@@ -1066,7 +1068,7 @@ static Widget s_hide_widgets[] = {
     },
 };
 
-static const char* TIMER_TYPES[] = {"Default", "Freeze at max", "Freeze at 0", "Count up from 0"};
+static const char* TIMER_TYPES[] = {"Default", "Frozen", "Freeze at 0", "Count up from 0"};
 static const char* FALLOUT_PLANE_TYPE[] = {"Normal", "Disabled", "Bouncy"};
 
 static Widget s_assist_widgets[] = {
@@ -1507,7 +1509,7 @@ static Widget s_stage_edit_widgets[] = {
     },
     {
         .type = WidgetType::Text,
-        .text = {"Stage Edits are activated on retry"},
+        .text = {"  Stage Edits are activated on retry"},
     },
 };
 

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -1518,7 +1518,7 @@ static const char* JUMP_COUNTS[] = {"One", "Two", "Infinite"};
 static Widget s_jump_classic_widgets[] = {
     {
         .type = WidgetType::Text,
-        .text = {"  Classic Jump-Mod from it's original release"},
+        .text = {"  Classic Jump-Mod from its original release"},
     },
     {.type = WidgetType::Separator},
     {.type = WidgetType::Header, .header = {"Configuration"}},


### PR DESCRIPTION
* Fixed buggy timer behavior (freeze-at-0 timer got broken somewhere along the way, and count-up timer didn't have any overflow protection)
* Added some code that'll make Stardust's custom timers work fine (and shouldn't affect vanilla timers at all)
* Cleaned up freecam's timer freeze code
* Cleaned up menus