### PR TITLE
Freecam Fixes

### DIFF
--- a/src/mods/freecam.cpp
+++ b/src/mods/freecam.cpp
@@ -2,7 +2,6 @@
 
 #include "mkb/mkb.h"
 
-#include "mkb/mkb2_ghidra.h"
 #include "systems/binds.h"
 #include "systems/pad.h"
 #include "systems/pref.h"
@@ -18,6 +17,9 @@ enum {
     EnabledPrevTick = 1 << 1,
 };
 }
+
+static constexpr float MAX_STICK = 60.f;
+static constexpr float MAX_TRIGGER = 128.f;
 
 static u32 s_flags;
 static Vec s_eye = {};
@@ -50,18 +52,18 @@ static void update_cam(mkb::Camera* camera, mkb::Ball* ball) {
         s_rot = mkb::cameras[0].rot;
     }
 
-    pad::StickInputs stick, substick;
-    pad::TriggerInputs trigger;
+    pad::StickState stick, substick;
+    pad::TriggerState trigger;
     pad::get_merged_stick(stick);
     pad::get_merged_substick(substick);
     pad::get_merged_triggers(trigger);
 
-    float stick_x = stick.x / 60.f;
-    float stick_y = stick.y / 60.f;
-    float substick_x = substick.x / 60.f;
-    float substick_y = substick.y / 60.f;
-    float trigger_left = trigger.l / 128.f;
-    float trigger_right = trigger.r / 128.f;
+    float stick_x = stick.x / MAX_STICK;
+    float stick_y = stick.y / MAX_STICK;
+    float substick_x = substick.x / MAX_STICK;
+    float substick_y = substick.y / MAX_STICK;
+    float trigger_left = trigger.l / MAX_TRIGGER;
+    float trigger_right = trigger.r / MAX_TRIGGER;
     bool fast = pad::button_down(mkb::PAD_BUTTON_Y);
     bool slow = pad::button_down(mkb::PAD_BUTTON_X);
 

--- a/src/mods/freecam.cpp
+++ b/src/mods/freecam.cpp
@@ -176,6 +176,24 @@ void tick() {
     s_flags &= ~Flags::EnabledThisTick;
     if (enabled()) {
         s_flags |= Flags::EnabledThisTick;
+
+        // Adjust turbo speed multiplier
+        int speed_mult = pref::get(pref::U8Pref::FreecamSpeedMult);
+        bool input_made = false;
+        if (pad::button_repeat(mkb::PAD_BUTTON_DOWN)) {
+            speed_mult--;
+            input_made = true;
+        }
+        if (pad::button_repeat(mkb::PAD_BUTTON_UP)) {
+            speed_mult++;
+            input_made = true;
+        }
+        speed_mult = CLAMP(speed_mult, TURBO_SPEED_MIN, TURBO_SPEED_MAX);
+        if (input_made) {
+            draw::notify(draw::WHITE, "Freecam Turbo Speed Factor: %dX", speed_mult);
+            pref::set(pref::U8Pref::FreecamSpeedMult, speed_mult);
+            pref::save();
+        }
     }
 }
 

--- a/src/mods/freecam.cpp
+++ b/src/mods/freecam.cpp
@@ -2,6 +2,7 @@
 
 #include "mkb/mkb.h"
 
+#include "mkb/mkb2_ghidra.h"
 #include "systems/binds.h"
 #include "systems/pad.h"
 #include "systems/pref.h"
@@ -40,7 +41,7 @@ static void get_merged_stick_inputs(MergedStickInputs& outInputs) {
     // know which player is active, like in menus
     // TODO account for d-pad control setting
     if (!pad::get_exclusive_mode()) {
-        for (s32 i = 0; i < 4; i++) {
+        for (u32 i = 0; i < LEN(mkb::pad_status_groups); i++) {
             mkb::PADStatus& status = mkb::pad_status_groups[i].raw;
             if (status.err == mkb::PAD_ERR_NONE) {
                 outInputs.rawX += status.stickX;

--- a/src/mods/freecam.cpp
+++ b/src/mods/freecam.cpp
@@ -18,9 +18,6 @@ enum {
 };
 }
 
-static constexpr float MAX_STICK = 60.f;
-static constexpr float MAX_TRIGGER = 128.f;
-
 static u32 s_flags;
 static Vec s_eye = {};
 static S16Vec s_rot = {};
@@ -58,12 +55,12 @@ static void update_cam(mkb::Camera* camera, mkb::Ball* ball) {
     pad::get_merged_substick(substick);
     pad::get_merged_triggers(trigger);
 
-    float stick_x = stick.x / MAX_STICK;
-    float stick_y = stick.y / MAX_STICK;
-    float substick_x = substick.x / MAX_STICK;
-    float substick_y = substick.y / MAX_STICK;
-    float trigger_left = trigger.l / MAX_TRIGGER;
-    float trigger_right = trigger.r / MAX_TRIGGER;
+    float stick_x = stick.x / static_cast<float>(pad::MAX_STICK);
+    float stick_y = stick.y / static_cast<float>(pad::MAX_STICK);
+    float substick_x = substick.x / static_cast<float>(pad::MAX_STICK);
+    float substick_y = substick.y / static_cast<float>(pad::MAX_STICK);
+    float trigger_left = trigger.l / static_cast<float>(pad::MAX_TRIGGER);
+    float trigger_right = trigger.r / static_cast<float>(pad::MAX_TRIGGER);
     bool fast = pad::button_down(mkb::PAD_BUTTON_Y);
     bool slow = pad::button_down(mkb::PAD_BUTTON_X);
 

--- a/src/mods/ilbattle.cpp
+++ b/src/mods/ilbattle.cpp
@@ -1,5 +1,6 @@
 #include "ilbattle.h"
 #include "mkb/mkb.h"
+#include "mods/freecam.h"
 #include "systems/binds.h"
 #include "systems/pad.h"
 #include "systems/pref.h"
@@ -393,7 +394,7 @@ void disp() {
         return;
     }
 
-    if (!pref::get(pref::BoolPref::IlBattleDisplay)) return;
+    if (!pref::get(pref::BoolPref::IlBattleDisplay) || freecam::should_hide_hud()) return;
 
     switch (s_state) {
         case IlBattleState::NotReady: {

--- a/src/mods/inputdisp.cpp
+++ b/src/mods/inputdisp.cpp
@@ -8,6 +8,7 @@
 #include "systems/pad.h"
 #include "systems/pref.h"
 #include "utils/draw.h"
+#include "utils/macro_utils.h"
 #include "utils/patch.h"
 
 namespace inputdisp {
@@ -47,6 +48,11 @@ static void get_merged_stick_inputs(MergedStickInputs& outInputs) {
                 outInputs.gameY += mkb::pad_status_groups[i].raw.stickY;
             }
         }
+
+        outInputs.rawX = CLAMP(outInputs.rawX, -128, 127);
+        outInputs.rawY = CLAMP(outInputs.rawY, -128, 127);
+        outInputs.gameX = CLAMP(outInputs.gameX, -60, 60);
+        outInputs.gameY = CLAMP(outInputs.gameY, -60, 60);
     }
 }
 
@@ -293,9 +299,7 @@ static void draw_raw_stick_inputs(const MergedStickInputs& stick_inputs) {
 }
 
 void disp() {
-    bool in_replay = mkb::sub_mode == mkb::SMD_OPTION_REPLAY_INIT ||
-                     mkb::sub_mode == mkb::SMD_OPTION_REPLAY_MAIN ||
-                     mkb::sub_mode == mkb::SMD_OPTION_REPLAY_PLAY_INIT ||
+    bool in_replay = mkb::sub_mode == mkb::SMD_OPTION_REPLAY_PLAY_INIT ||
                      mkb::sub_mode == mkb::SMD_OPTION_REPLAY_PLAY_MAIN ||
                      mkb::sub_mode == mkb::SMD_EXOPT_REPLAY_LOAD_INIT ||
                      mkb::sub_mode == mkb::SMD_EXOPT_REPLAY_LOAD_MAIN ||

--- a/src/mods/inputdisp.cpp
+++ b/src/mods/inputdisp.cpp
@@ -119,7 +119,7 @@ void tick() {
                         !pref::get(pref::BoolPref::InputDispRawStickInputs)));
 }
 
-static bool get_notch_pos(const pad::StickInputs& stick_inputs, Vec2d* out_pos) {
+static bool get_notch_pos(const pad::StickState& stick_inputs, Vec2d* out_pos) {
     constexpr f32 DIAG = 0.7071067811865476f;  // sin(pi/4) or sqrt(2)/2
     bool notch_found = false;
 
@@ -192,7 +192,7 @@ static mkb::GXColor get_color() {
     return {};
 }
 
-static void draw_stick(const pad::StickInputs& raw_stick_inputs, const Vec2d& center, f32 scale) {
+static void draw_stick(const pad::StickState& raw_stick_inputs, const Vec2d& center, f32 scale) {
     mkb::GXColor chosen_color = get_color();
 
     draw_ring(8, center, 54 * scale, 60 * scale, {0x00, 0x00, 0x00, 0xFF});
@@ -234,7 +234,7 @@ static void draw_buttons(const Vec2d& center, f32 scale) {
     }
 }
 
-static void draw_notch_indicators(const pad::StickInputs& stick_inputs, const Vec2d& center,
+static void draw_notch_indicators(const pad::StickState& stick_inputs, const Vec2d& center,
                                   f32 scale) {
     if (!pref::get(pref::BoolPref::InputDispNotchIndicators)) return;
 
@@ -248,8 +248,8 @@ static void draw_notch_indicators(const pad::StickInputs& stick_inputs, const Ve
     }
 }
 
-static void draw_raw_stick_inputs(const pad::StickInputs& raw_stick_inputs,
-                                  const pad::StickInputs& stick_inputs) {
+static void draw_raw_stick_inputs(const pad::StickState& raw_stick_inputs,
+                                  const pad::StickState& stick_inputs) {
     if (!pref::get(pref::BoolPref::InputDispRawStickInputs)) return;
 
     Vec2d center = {
@@ -277,7 +277,7 @@ void disp() {
         pref::get(pref::BoolPref::InputDispCenterLocation) ? Vec2d{430, 60} : Vec2d{534, 60};
     f32 scale = 0.6f;
 
-    pad::StickInputs raw_stick, stick;
+    pad::StickState raw_stick, stick;
     pad::get_merged_raw_stick(raw_stick);
     pad::get_merged_stick(stick);
 

--- a/src/mods/inputdisp.cpp
+++ b/src/mods/inputdisp.cpp
@@ -123,28 +123,28 @@ static bool get_notch_pos(const pad::StickState& stick_inputs, Vec2d* out_pos) {
     constexpr f32 DIAG = 0.7071067811865476f;  // sin(pi/4) or sqrt(2)/2
     bool notch_found = false;
 
-    if (stick_inputs.x == 0 && stick_inputs.y == 60) {
+    if (stick_inputs.x == 0 && stick_inputs.y == pad::MAX_STICK) {
         *out_pos = {0, 1};
         notch_found = true;
-    } else if (stick_inputs.x == 0 && stick_inputs.y == -60) {
+    } else if (stick_inputs.x == 0 && stick_inputs.y == -pad::MAX_STICK) {
         *out_pos = {0, -1};
         notch_found = true;
-    } else if (stick_inputs.x == 60 && stick_inputs.y == 0) {
+    } else if (stick_inputs.x == pad::MAX_STICK && stick_inputs.y == 0) {
         *out_pos = {1, 0};
         notch_found = true;
-    } else if (stick_inputs.x == -60 && stick_inputs.y == 0) {
+    } else if (stick_inputs.x == -pad::MAX_STICK && stick_inputs.y == 0) {
         *out_pos = {-1, 0};
         notch_found = true;
-    } else if (stick_inputs.x == 60 && stick_inputs.y == 60) {
+    } else if (stick_inputs.x == pad::MAX_STICK && stick_inputs.y == pad::MAX_STICK) {
         *out_pos = {DIAG, DIAG};
         notch_found = true;
-    } else if (stick_inputs.x == 60 && stick_inputs.y == -60) {
+    } else if (stick_inputs.x == pad::MAX_STICK && stick_inputs.y == -pad::MAX_STICK) {
         *out_pos = {DIAG, -DIAG};
         notch_found = true;
-    } else if (stick_inputs.x == -60 && stick_inputs.y == 60) {
+    } else if (stick_inputs.x == -pad::MAX_STICK && stick_inputs.y == pad::MAX_STICK) {
         *out_pos = {-DIAG, DIAG};
         notch_found = true;
-    } else if (stick_inputs.x == -60 && stick_inputs.y == -60) {
+    } else if (stick_inputs.x == -pad::MAX_STICK && stick_inputs.y == -pad::MAX_STICK) {
         *out_pos = {-DIAG, -DIAG};
         notch_found = true;
     }

--- a/src/mods/inputdisp.cpp
+++ b/src/mods/inputdisp.cpp
@@ -13,13 +13,6 @@
 
 namespace inputdisp {
 
-struct MergedStickInputs {
-    s32 rawX;
-    s32 rawY;
-    s32 gameX;
-    s32 gameY;
-};
-
 enum class InputDispColorType {
     Default = 0,
     RGB = 1,
@@ -29,32 +22,7 @@ enum class InputDispColorType {
 
 static patch::Tramp<decltype(&mkb::create_speed_sprites)> s_create_speed_sprites_tramp;
 
-static mkb::PADStatus s_raw_inputs[4];
-
 static u32 s_rainbow;
-
-static void get_merged_stick_inputs(MergedStickInputs& outInputs) {
-    outInputs = {};
-
-    // Accumulate stick inputs from all controllers since we don't always
-    // know which player is active, like in menus
-    // TODO account for d-pad control setting
-    if (!pad::get_exclusive_mode()) {
-        for (s32 i = 0; i < 4; i++) {
-            if (s_raw_inputs[i].err == mkb::PAD_ERR_NONE) {
-                outInputs.rawX += s_raw_inputs[i].stickX;
-                outInputs.rawY += s_raw_inputs[i].stickY;
-                outInputs.gameX += mkb::pad_status_groups[i].raw.stickX;
-                outInputs.gameY += mkb::pad_status_groups[i].raw.stickY;
-            }
-        }
-
-        outInputs.rawX = CLAMP(outInputs.rawX, -128, 127);
-        outInputs.rawY = CLAMP(outInputs.rawY, -128, 127);
-        outInputs.gameX = CLAMP(outInputs.gameX, -60, 60);
-        outInputs.gameY = CLAMP(outInputs.gameY, -60, 60);
-    }
-}
 
 static void draw_ring(u32 pts, Vec2d center, f32 inner_radius, f32 outer_radius,
                       mkb::GXColor color) {
@@ -144,10 +112,6 @@ void init() {
                          [](f32 x, f32 y) { s_create_speed_sprites_tramp.dest(x + 5, y); });
 }
 
-void on_PADRead(mkb::PADStatus* statuses) {
-    mkb::memcpy(s_raw_inputs, statuses, sizeof(s_raw_inputs));
-}
-
 void tick() {
     s_rainbow = (s_rainbow + 3) % 1080;
     set_sprite_visible(!pref::get(pref::BoolPref::InputDisp) ||
@@ -155,32 +119,32 @@ void tick() {
                         !pref::get(pref::BoolPref::InputDispRawStickInputs)));
 }
 
-static bool get_notch_pos(const MergedStickInputs& stick_inputs, Vec2d* out_pos) {
+static bool get_notch_pos(const pad::StickInputs& stick_inputs, Vec2d* out_pos) {
     constexpr f32 DIAG = 0.7071067811865476f;  // sin(pi/4) or sqrt(2)/2
     bool notch_found = false;
 
-    if (stick_inputs.gameX == 0 && stick_inputs.gameY == 60) {
+    if (stick_inputs.x == 0 && stick_inputs.y == 60) {
         *out_pos = {0, 1};
         notch_found = true;
-    } else if (stick_inputs.gameX == 0 && stick_inputs.gameY == -60) {
+    } else if (stick_inputs.x == 0 && stick_inputs.y == -60) {
         *out_pos = {0, -1};
         notch_found = true;
-    } else if (stick_inputs.gameX == 60 && stick_inputs.gameY == 0) {
+    } else if (stick_inputs.x == 60 && stick_inputs.y == 0) {
         *out_pos = {1, 0};
         notch_found = true;
-    } else if (stick_inputs.gameX == -60 && stick_inputs.gameY == 0) {
+    } else if (stick_inputs.x == -60 && stick_inputs.y == 0) {
         *out_pos = {-1, 0};
         notch_found = true;
-    } else if (stick_inputs.gameX == 60 && stick_inputs.gameY == 60) {
+    } else if (stick_inputs.x == 60 && stick_inputs.y == 60) {
         *out_pos = {DIAG, DIAG};
         notch_found = true;
-    } else if (stick_inputs.gameX == 60 && stick_inputs.gameY == -60) {
+    } else if (stick_inputs.x == 60 && stick_inputs.y == -60) {
         *out_pos = {DIAG, -DIAG};
         notch_found = true;
-    } else if (stick_inputs.gameX == -60 && stick_inputs.gameY == 60) {
+    } else if (stick_inputs.x == -60 && stick_inputs.y == 60) {
         *out_pos = {-DIAG, DIAG};
         notch_found = true;
-    } else if (stick_inputs.gameX == -60 && stick_inputs.gameY == -60) {
+    } else if (stick_inputs.x == -60 && stick_inputs.y == -60) {
         *out_pos = {-DIAG, -DIAG};
         notch_found = true;
     }
@@ -228,7 +192,7 @@ static mkb::GXColor get_color() {
     return {};
 }
 
-static void draw_stick(const MergedStickInputs& stick_inputs, const Vec2d& center, f32 scale) {
+static void draw_stick(const pad::StickInputs& raw_stick_inputs, const Vec2d& center, f32 scale) {
     mkb::GXColor chosen_color = get_color();
 
     draw_ring(8, center, 54 * scale, 60 * scale, {0x00, 0x00, 0x00, 0xFF});
@@ -236,8 +200,8 @@ static void draw_stick(const MergedStickInputs& stick_inputs, const Vec2d& cente
     draw_ring(8, center, 50 * scale, 58 * scale, chosen_color);
 
     Vec2d scaled_input = {
-        center.x + static_cast<f32>(stick_inputs.rawX) / 2.7f * scale,
-        center.y - static_cast<f32>(stick_inputs.rawY) / 2.7f * scale,
+        center.x + static_cast<f32>(raw_stick_inputs.x) / 2.7f * scale,
+        center.y - static_cast<f32>(raw_stick_inputs.y) / 2.7f * scale,
     };
 
     draw_circle(16, scaled_input, 9 * scale, {0xFF, 0xFF, 0xFF, 0xFF});
@@ -270,7 +234,7 @@ static void draw_buttons(const Vec2d& center, f32 scale) {
     }
 }
 
-static void draw_notch_indicators(const MergedStickInputs& stick_inputs, const Vec2d& center,
+static void draw_notch_indicators(const pad::StickInputs& stick_inputs, const Vec2d& center,
                                   f32 scale) {
     if (!pref::get(pref::BoolPref::InputDispNotchIndicators)) return;
 
@@ -284,7 +248,8 @@ static void draw_notch_indicators(const MergedStickInputs& stick_inputs, const V
     }
 }
 
-static void draw_raw_stick_inputs(const MergedStickInputs& stick_inputs) {
+static void draw_raw_stick_inputs(const pad::StickInputs& raw_stick_inputs,
+                                  const pad::StickInputs& stick_inputs) {
     if (!pref::get(pref::BoolPref::InputDispRawStickInputs)) return;
 
     Vec2d center = {
@@ -292,10 +257,10 @@ static void draw_raw_stick_inputs(const MergedStickInputs& stick_inputs) {
         .y = 28.f,
     };
 
-    draw::debug_text(center.x, center.y + 0 * 14, draw::WHITE, "rX: %d", stick_inputs.rawX);
-    draw::debug_text(center.x, center.y + 1 * 14, draw::WHITE, "rY: %d", stick_inputs.rawY);
-    draw::debug_text(center.x, center.y + 2 * 14, draw::WHITE, "gX: %d", stick_inputs.gameX);
-    draw::debug_text(center.x, center.y + 3 * 14, draw::WHITE, "gY: %d", stick_inputs.gameY);
+    draw::debug_text(center.x, center.y + 0 * 14, draw::WHITE, "rX: %d", raw_stick_inputs.x);
+    draw::debug_text(center.x, center.y + 1 * 14, draw::WHITE, "rY: %d", raw_stick_inputs.y);
+    draw::debug_text(center.x, center.y + 2 * 14, draw::WHITE, "gX: %d", stick_inputs.x);
+    draw::debug_text(center.x, center.y + 3 * 14, draw::WHITE, "gY: %d", stick_inputs.y);
 }
 
 void disp() {
@@ -312,13 +277,15 @@ void disp() {
         pref::get(pref::BoolPref::InputDispCenterLocation) ? Vec2d{430, 60} : Vec2d{534, 60};
     f32 scale = 0.6f;
 
-    MergedStickInputs stick_inputs;
-    get_merged_stick_inputs(stick_inputs);
+    pad::StickInputs raw_stick, stick;
+    pad::get_merged_raw_stick(raw_stick);
+    pad::get_merged_stick(stick);
 
-    draw_stick(stick_inputs, center, scale);
+    draw_stick(raw_stick, center, scale);
     draw_buttons(center, scale);
-    draw_notch_indicators(stick_inputs, center, scale);
-    draw_raw_stick_inputs(stick_inputs);
+
+    draw_notch_indicators(stick, center, scale);
+    draw_raw_stick_inputs(raw_stick, stick);
 }
 
 }  // namespace inputdisp

--- a/src/mods/physics.cpp
+++ b/src/mods/physics.cpp
@@ -119,9 +119,8 @@ void disp() {
         mkb::sub_mode != mkb::SMD_GAME_PLAY_INIT && mkb::sub_mode != mkb::SMD_GAME_PLAY_MAIN)
         return;
 
-    if (freecam::should_hide_hud()) return;
-
-    if (using_custom_physics() && pref::get(pref::BoolPref::CustomPhysicsDisp)) {
+    if (using_custom_physics() && pref::get(pref::BoolPref::CustomPhysicsDisp) &&
+        !freecam::should_hide_hud()) {
         mkb::textdraw_reset();
         mkb::textdraw_set_font(mkb::FONT32_ASC_8x16);
         u32 x = 634;

--- a/src/mods/physics.cpp
+++ b/src/mods/physics.cpp
@@ -1,5 +1,6 @@
 #include "physics.h"
 #include "mkb/mkb.h"
+#include "mods/freecam.h"
 #include "systems/pad.h"
 #include "systems/pref.h"
 #include "utils/draw.h"
@@ -117,6 +118,8 @@ void disp() {
     if (mkb::sub_mode != mkb::SMD_GAME_READY_INIT && mkb::sub_mode != mkb::SMD_GAME_READY_MAIN &&
         mkb::sub_mode != mkb::SMD_GAME_PLAY_INIT && mkb::sub_mode != mkb::SMD_GAME_PLAY_MAIN)
         return;
+
+    if (freecam::should_hide_hud()) return;
 
     if (using_custom_physics() && pref::get(pref::BoolPref::CustomPhysicsDisp)) {
         mkb::textdraw_reset();

--- a/src/systems/main.cpp
+++ b/src/systems/main.cpp
@@ -120,11 +120,11 @@ void init() {
         cardio::tick();
         unlock::tick();
         fallout::tick();
-        physics::tick();
         iw::tick();
         savest_ui::tick();
         menu_impl::tick();
         jump::tick();
+        physics::tick();
         inputdisp::tick();
         gotostory::tick();
         cmseg::tick();

--- a/src/systems/main.cpp
+++ b/src/systems/main.cpp
@@ -105,7 +105,8 @@ void init() {
 
         // Dpad can modify effective stick input, shown by input display
         dpad::on_PADRead(statuses);
-        inputdisp::on_PADRead(statuses);
+        // pad collects original inputs before they are modified by the game
+        pad::on_PADRead(statuses);
 
         return ret;
     });

--- a/src/systems/pad.cpp
+++ b/src/systems/pad.cpp
@@ -86,7 +86,7 @@ void get_merged_triggers(TriggerInputs& out) {
     out.r = CLAMP(out.r, 0, 255);
 }
 
-void on_PADREAD(mkb::PADStatus* statuses) {
+void on_PADRead(mkb::PADStatus* statuses) {
     mkb::memcpy(s_original_inputs, statuses, sizeof(s_original_inputs));
 }
 

--- a/src/systems/pad.cpp
+++ b/src/systems/pad.cpp
@@ -318,12 +318,12 @@ void tick() {
         }
         s_analog_state.raw_stick_x = CLAMP(s_analog_state.raw_stick_x, -128, 127);
         s_analog_state.raw_stick_y = CLAMP(s_analog_state.raw_stick_y, -128, 127);
-        s_analog_state.stick_x = CLAMP(s_analog_state.stick_x, -60, 60);
-        s_analog_state.stick_y = CLAMP(s_analog_state.stick_y, -60, 60);
-        s_analog_state.substick_x = CLAMP(s_analog_state.substick_x, -60, 60);
-        s_analog_state.substick_y = CLAMP(s_analog_state.substick_y, -60, 60);
-        s_analog_state.trigger_l = CLAMP(s_analog_state.trigger_l, 0, 255);
-        s_analog_state.trigger_r = CLAMP(s_analog_state.trigger_r, 0, 255);
+        s_analog_state.stick_x = CLAMP(s_analog_state.stick_x, -MAX_STICK, MAX_STICK);
+        s_analog_state.stick_y = CLAMP(s_analog_state.stick_y, -MAX_STICK, MAX_STICK);
+        s_analog_state.substick_x = CLAMP(s_analog_state.substick_x, -MAX_STICK, MAX_STICK);
+        s_analog_state.substick_y = CLAMP(s_analog_state.substick_y, -MAX_STICK, MAX_STICK);
+        s_analog_state.trigger_l = CLAMP(s_analog_state.trigger_l, 0, MAX_TRIGGER);
+        s_analog_state.trigger_r = CLAMP(s_analog_state.trigger_r, 0, MAX_TRIGGER);
     }
 
     update_konami();

--- a/src/systems/pad.cpp
+++ b/src/systems/pad.cpp
@@ -292,13 +292,13 @@ void tick() {
     mkb::memcpy(s_pad_status_groups, mkb::pad_status_groups, sizeof(mkb::pad_status_groups));
     mkb::memcpy(s_analog_inputs, mkb::analog_inputs, sizeof(mkb::analog_inputs));
 
+    s_analog_state = {};
     if (s_exclusive_mode) {
         // Zero controller inputs in the game
         mkb::merged_analog_inputs = {};
         mkb::merged_digital_inputs = {};
         memset(mkb::pad_status_groups, 0, sizeof(mkb::pad_status_groups));
         memset(mkb::analog_inputs, 0, sizeof(mkb::analog_inputs));
-        s_analog_state = {};
     } else {
         // update analog state
         for (u32 i = 0; i < LEN(mkb::pad_status_groups); i++) {

--- a/src/systems/pad.h
+++ b/src/systems/pad.h
@@ -16,12 +16,12 @@ enum Dir {
     DIR_NONE = -1,
 };
 
-struct StickInputs {
+struct StickState {
     s32 x;
     s32 y;
 };
 
-struct TriggerInputs {
+struct TriggerState {
     s32 l;
     s32 r;
 };
@@ -60,9 +60,9 @@ bool dir_repeat(Dir dir, bool priority = false);   // Only works for cardinal di
 void reset_dir_repeat();
 bool konami_pressed();
 
-void get_merged_raw_stick(StickInputs& out);  // stick before game makes alterations
-void get_merged_stick(StickInputs& out);
-void get_merged_substick(StickInputs& out);
-void get_merged_triggers(TriggerInputs& out);
+void get_merged_raw_stick(StickState& out);  // stick before game makes alterations
+void get_merged_stick(StickState& out);
+void get_merged_substick(StickState& out);
+void get_merged_triggers(TriggerState& out);
 
 }  // namespace pad

--- a/src/systems/pad.h
+++ b/src/systems/pad.h
@@ -16,10 +16,21 @@ enum Dir {
     DIR_NONE = -1,
 };
 
+struct StickInputs {
+    s32 x;
+    s32 y;
+};
+
+struct TriggerInputs {
+    s32 l;
+    s32 r;
+};
+
 void init();
 // Tick functions to be run at different points in the game loop
 void on_frame_start();
 void tick();  // Run this after controller inputs are read and processed by the game
+void on_PADRead(mkb::PADStatus* statuses);
 
 // In exclusive mode, inputs only register
 // when passing `true` to the optional second argument of the input checking functions,
@@ -48,5 +59,10 @@ bool dir_pressed(Dir dir, bool priority = false);  // Only works for cardinal di
 bool dir_repeat(Dir dir, bool priority = false);   // Only works for cardinal directions
 void reset_dir_repeat();
 bool konami_pressed();
+
+void get_merged_raw_stick(StickInputs out);  // stick before game makes alterations
+void get_merged_stick(StickInputs out);
+void get_merged_substick(StickInputs out);
+void get_merged_triggers(TriggerInputs out);
 
 }  // namespace pad

--- a/src/systems/pad.h
+++ b/src/systems/pad.h
@@ -26,6 +26,9 @@ struct TriggerState {
     s32 r;
 };
 
+static constexpr int MAX_STICK = 60.f;
+static constexpr int MAX_TRIGGER = 128.f;
+
 void init();
 // Tick functions to be run at different points in the game loop
 void on_frame_start();

--- a/src/systems/pad.h
+++ b/src/systems/pad.h
@@ -26,8 +26,8 @@ struct TriggerState {
     s32 r;
 };
 
-static constexpr int MAX_STICK = 60.f;
-static constexpr int MAX_TRIGGER = 128.f;
+static constexpr int MAX_STICK = 60;
+static constexpr int MAX_TRIGGER = 128;
 
 void init();
 // Tick functions to be run at different points in the game loop

--- a/src/systems/pad.h
+++ b/src/systems/pad.h
@@ -60,9 +60,9 @@ bool dir_repeat(Dir dir, bool priority = false);   // Only works for cardinal di
 void reset_dir_repeat();
 bool konami_pressed();
 
-void get_merged_raw_stick(StickInputs out);  // stick before game makes alterations
-void get_merged_stick(StickInputs out);
-void get_merged_substick(StickInputs out);
-void get_merged_triggers(TriggerInputs out);
+void get_merged_raw_stick(StickInputs& out);  // stick before game makes alterations
+void get_merged_stick(StickInputs& out);
+void get_merged_substick(StickInputs& out);
+void get_merged_triggers(TriggerInputs& out);
 
 }  // namespace pad


### PR DESCRIPTION
* Freecam uses inputs from any controller (Fixes #40)
* Freecam works in replays (Fixes #26)
* Input Display values are clamped (holding down on two controllers used to draw the stick outside of the display, it doesn't anymore)
* ILBattle and Physics displays hide when Freecam Hide Hud Pref is active
* Fixed bug with Physics and Jump mod interaction