### PR TITLE
Validation Overhaul

### DIFF
--- a/src/mods/ilbattle.cpp
+++ b/src/mods/ilbattle.cpp
@@ -39,8 +39,6 @@ static constexpr u32 MINUTE_FRAMES = SECOND_FRAMES * 60;  // frames per minute
 static constexpr u32 HOUR_FRAMES = MINUTE_FRAMES * 60;    // frames per hour
 // battle trackers
 static u32 s_battle_frames = 0;
-static bool s_valid_run = false;
-static s16 s_paused_frame = 0;
 static u32 s_battle_length = 0;
 static u32 s_battle_stage_id = 0;
 static u32 s_main_mode_play_timer = 0;
@@ -198,7 +196,7 @@ void clear_display() {
         convert_battle_length(IlBattleLength(pref::get(pref::U8Pref::IlBattleLength)));
 }
 
-void new_battle() {
+static void new_battle() {
     clear_display();
     s_state = IlBattleState::WaitForFirstRetry;
 }
@@ -213,6 +211,12 @@ static void track_first_retry() {
 }
 
 static void run_battle_timer() {
+    if (mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT) {
+        if (!s_accepted_retry) {  // track attempt counts
+            s_attempts++;
+            s_accepted_retry = true;
+        }
+    }
     if (IlBattleLength(pref::get(pref::U8Pref::IlBattleLength)) == IlBattleLength::Endless) {
         // timer is endless
         s_battle_frames++;
@@ -223,17 +227,9 @@ static void run_battle_timer() {
     }
 }
 
-static void track_best() {
-    if (mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT) return;
-
+void update_best() {
     s16 current_frames = mkb::mode_info.stage_time_frames_remaining;
     u32 current_score = mkb::balls[mkb::curr_player_idx].score;
-    bool on_incorrect_stage = s_main_mode_play_timer > 0 &&
-                              s_battle_stage_id != mkb::current_stage_id &&
-                              mkb::main_mode == mkb::MD_GAME;
-    bool valid = (s_valid_run && s_paused_frame <= current_frames) ||
-                 s_paused_frame == mkb::mode_info.stage_time_frames_remaining;
-    if (!valid || on_incorrect_stage) return;
 
     u32 calculated_score = score_calc(current_score);
 
@@ -261,39 +257,18 @@ static void track_best() {
     }
 }
 
-static void track_invalid_pauses() {
-    bool paused_now = *reinterpret_cast<u32*>(0x805BC474) & 8;
-    if (mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT) {
-        s_valid_run = true;
-        s_paused_frame = 0;       // attempt is now valid
-        if (!s_accepted_retry) {  // track attempt counts
-            s_attempts++;
-            s_accepted_retry = true;
-        }
-    }
-    if (mkb::sub_mode == mkb::SMD_GAME_PLAY_MAIN && paused_now && s_paused_frame == 0) {
-        s_paused_frame = mkb::mode_info.stage_time_frames_remaining;
-    } else if ((mkb::sub_mode == mkb::SMD_GAME_PLAY_MAIN && paused_now) ||
-               libsavest::state_loaded_this_frame()) {
-        s_valid_run = false;
-    }
-}
+void track_valid_attempt() {
+    bool on_incorrect_stage = s_main_mode_play_timer > 0 &&
+                              s_battle_stage_id != mkb::current_stage_id &&
+                              mkb::main_mode == mkb::MD_GAME;
+    if (on_incorrect_stage) return;
 
-static void track_final_attempt() {
-    bool paused_now = *reinterpret_cast<u32*>(0x805BC474) & 8;
-    // End battle if: Paused, Fallout, or Time Over
-    if (paused_now || mkb::sub_mode == mkb::SMD_GAME_RINGOUT_INIT ||
-        mkb::sub_mode == mkb::SMD_GAME_RINGOUT_MAIN ||
-        mkb::sub_mode == mkb::SMD_GAME_TIMEOVER_INIT ||
-        mkb::sub_mode == mkb::SMD_GAME_TIMEOVER_MAIN) {
-        s_state = IlBattleState::BattleDone;
-    }
-    // Player has entered goal...
-    // Save time & enter postgoal phase for score
-    else if (mkb::sub_mode == mkb::SMD_GAME_GOAL_INIT || mkb::sub_mode == mkb::SMD_GAME_GOAL_MAIN) {
+    if (s_state == IlBattleState::BattleRunning) {
+        update_best();
+    } else if (s_state == IlBattleState::BuzzerBeater) {
         s16 pre_buzzer_time = s_best_frames;
         u32 pre_buzzer_score = s_best_score;
-        track_best();
+        update_best();
         s_state = IlBattleState::BuzzerBeaterPostgoal;
         // time buzzer beater
         if (pre_buzzer_time < s_best_frames) {
@@ -303,15 +278,24 @@ static void track_final_attempt() {
         if (pre_buzzer_score < s_best_score) {
             s_score_buzzer = true;
         }
-
     }
-    // Game is no longer in goal phase...
-    // Save score and end battle
-    else if (s_state == IlBattleState::BuzzerBeaterPostgoal &&
-             !(mkb::sub_mode == mkb::SMD_GAME_GOAL_INIT ||
-               mkb::sub_mode == mkb::SMD_GAME_GOAL_MAIN)) {
+}
+
+static void final_attempt() {
+    bool paused_now = *reinterpret_cast<u32*>(0x805BC474) & 8;
+    // End battle if: Paused, Fallout, or Time Over
+    if (paused_now || mkb::sub_mode == mkb::SMD_GAME_RINGOUT_INIT ||
+        mkb::sub_mode == mkb::SMD_GAME_RINGOUT_MAIN ||
+        mkb::sub_mode == mkb::SMD_GAME_TIMEOVER_INIT ||
+        mkb::sub_mode == mkb::SMD_GAME_TIMEOVER_MAIN) {
+        s_state = IlBattleState::BattleDone;
+    }
+}
+
+static void track_postgoal() {
+    if (mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT && mkb::sub_mode != mkb::SMD_GAME_GOAL_MAIN) {
         u32 pre_buzzer_score = s_best_score;
-        track_best();
+        update_best();
         s_state = IlBattleState::BattleDone;
         // score buzzer beater (track again if there are post goals)
         if (pre_buzzer_score < s_best_score) {
@@ -330,7 +314,7 @@ void tick() {
         s_accepted_retry = false;
     }
 
-    if (mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT) {
+    if (mkb::sub_mode != mkb::SMD_GAME_PLAY_MAIN) {
         s_accepted_tie = false;
     }
 
@@ -354,19 +338,15 @@ void tick() {
             break;
         }
         case IlBattleState::BattleRunning: {
-            track_invalid_pauses();
-            track_best();
-            run_battle_timer();  // TODO: Implement realtime timer (without loads), if I figure how
+            run_battle_timer();
             break;
         }
         case IlBattleState::BuzzerBeater: {
-            track_invalid_pauses();
-            track_final_attempt();
+            final_attempt();
             break;
         }
         case IlBattleState::BuzzerBeaterPostgoal: {
-            track_invalid_pauses();
-            track_final_attempt();
+            track_postgoal();
             break;
         }
         default: {

--- a/src/mods/ilbattle.cpp
+++ b/src/mods/ilbattle.cpp
@@ -1,5 +1,6 @@
 #include "ilbattle.h"
 #include "mkb/mkb.h"
+#include "mods/validate.h"
 #include "systems/binds.h"
 #include "systems/pad.h"
 #include "systems/pref.h"
@@ -257,7 +258,9 @@ void update_best() {
     }
 }
 
-void track_valid_attempt() {
+void validate_attempt() {
+    if (!validate::was_run_valid(true)) return;
+
     bool on_incorrect_stage = s_main_mode_play_timer > 0 &&
                               s_battle_stage_id != mkb::current_stage_id &&
                               mkb::main_mode == mkb::MD_GAME;

--- a/src/mods/ilbattle.h
+++ b/src/mods/ilbattle.h
@@ -6,8 +6,8 @@ namespace ilbattle {
 
 static constexpr u32 NUM_LENGTHS = 4;
 
+void track_valid_attempt();
 void tick();
 void disp();
-void new_battle();
 
 }  // namespace ilbattle

--- a/src/mods/ilbattle.h
+++ b/src/mods/ilbattle.h
@@ -6,7 +6,7 @@ namespace ilbattle {
 
 static constexpr u32 NUM_LENGTHS = 4;
 
-void track_valid_attempt();
+void validate_attempt();
 void tick();
 void disp();
 

--- a/src/mods/ilmark.cpp
+++ b/src/mods/ilmark.cpp
@@ -3,6 +3,7 @@
 #include "mkb/mkb.h"
 #include "mods/freecam.h"
 #include "mods/physics.h"
+#include "mods/validate.h"
 #include "systems/menu_impl.h"
 #include "systems/pad.h"
 #include "systems/pref.h"
@@ -23,7 +24,10 @@ void init() {
     s_is_romhack = mkb::strcmp(gamecode, "GM2E8P") != 0;
 }
 
-void set_valid() { s_valid_run = true; }
+void validate_attempt() {
+    if (!validate::was_run_valid(false)) return;
+    s_valid_run = true;
+}
 
 void tick() {
     if (mkb::sub_mode != mkb::SMD_GAME_PLAY_MAIN && mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT &&

--- a/src/mods/ilmark.cpp
+++ b/src/mods/ilmark.cpp
@@ -15,33 +15,7 @@
 namespace ilmark {
 
 static bool s_valid_run = false;
-static s16 s_paused_frame = 0;
 static bool s_is_romhack = false;
-
-static constexpr pref::BoolPref INVALID_BOOL_PREFS[] = {
-    pref::BoolPref::DisableFalloutVolumes,
-    pref::BoolPref::JumpMod,
-    pref::BoolPref::Marathon,
-    pref::BoolPref::DebugMode,
-};
-
-static constexpr pref::U8Pref INVALID_U8_PREFS[] = {
-    pref::U8Pref::TimerType,        pref::U8Pref::Friction,         pref::U8Pref::Restitution,
-    pref::U8Pref::FalloutPlaneType, pref::U8Pref::StageEditVariant,
-};
-
-void disable_invalidating_settings() {
-    // set all bool prefs to default
-    for (u8 i = 0; i < LEN(INVALID_BOOL_PREFS); i++) {
-        pref::set(INVALID_BOOL_PREFS[i], pref::get_default(INVALID_BOOL_PREFS[i]));
-    }
-    // set all u8 prefs to default
-    for (u8 i = 0; i < LEN(INVALID_U8_PREFS); i++) {
-        pref::set(INVALID_U8_PREFS[i], pref::get_default(INVALID_U8_PREFS[i]));
-    }
-
-    pref::save();
-}
 
 void init() {
     char gamecode[7] = {};
@@ -49,49 +23,16 @@ void init() {
     s_is_romhack = mkb::strcmp(gamecode, "GM2E8P") != 0;
 }
 
+void set_valid() { s_valid_run = true; }
+
 void tick() {
-    if (mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT) {
-        s_valid_run = true;
-        s_paused_frame = 0;
-
-    } else if (mkb::sub_mode == mkb::SMD_GAME_PLAY_MAIN) {
-        bool paused_now = *reinterpret_cast<u32*>(0x805BC474) & 8;
-        if (paused_now) {
-            if (s_paused_frame == 0) {
-                s_paused_frame = mkb::mode_info.stage_time_frames_remaining;
-            } else {
-                s_valid_run = false;
-            }
-        }
-        // Loading savestates is disallowed
-        if (libsavest::state_loaded_this_frame()) s_valid_run = false;
-
-        // Using dpad controls is disallowed
-        bool dpad_down =
-            pad::button_down(mkb::PAD_BUTTON_DOWN) || pad::button_down(mkb::PAD_BUTTON_LEFT) ||
-            pad::button_down(mkb::PAD_BUTTON_RIGHT) || pad::button_down(mkb::PAD_BUTTON_UP);
-        if (pref::get(pref::BoolPref::DpadControls) && dpad_down) s_valid_run = false;
-
-        // Opening the mod menu is disallowed
-        if (menu_impl::is_visible()) s_valid_run = false;
-
-        // Physics must be default or custom (with all default values)
-        if (physics::using_custom_physics()) s_valid_run = false;
-
-        // Invalid bool prefs are enabled
-        for (u8 i = 0; i < LEN(INVALID_BOOL_PREFS); i++) {
-            if (pref::get(INVALID_BOOL_PREFS[i]) != pref::get_default(INVALID_BOOL_PREFS[i])) {
-                s_valid_run = false;
-            }
-        }
-        // Invalid u8 prefs are enabled
-        for (u8 i = 0; i < LEN(INVALID_U8_PREFS); i++) {
-            if (pref::get(INVALID_U8_PREFS[i]) != pref::get_default(INVALID_U8_PREFS[i])) {
-                s_valid_run = false;
-            }
-        }
-    } else if (mkb::sub_mode == mkb::SMD_GAME_GOAL_INIT) {
-        s_valid_run = s_valid_run && s_paused_frame <= mkb::mode_info.stage_time_frames_remaining;
+    if (mkb::sub_mode != mkb::SMD_GAME_PLAY_MAIN && mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT &&
+        mkb::sub_mode != mkb::SMD_GAME_GOAL_MAIN &&
+        mkb::sub_mode != mkb::SMD_GAME_GOAL_REPLAY_INIT &&
+        mkb::sub_mode != mkb::SMD_GAME_GOAL_REPLAY_MAIN &&
+        mkb::sub_mode != mkb::SMD_GAME_BONUS_CLEAR_INIT &&
+        mkb::sub_mode != mkb::SMD_GAME_BONUS_CLEAR_MAIN) {
+        s_valid_run = false;
     }
 }
 

--- a/src/mods/ilmark.h
+++ b/src/mods/ilmark.h
@@ -2,8 +2,7 @@
 
 namespace ilmark {
 
-void set_valid();
-
+void validate_attempt();
 void init();
 void tick();
 void disp();

--- a/src/mods/ilmark.h
+++ b/src/mods/ilmark.h
@@ -2,7 +2,7 @@
 
 namespace ilmark {
 
-void disable_invalidating_settings();
+void set_valid();
 
 void init();
 void tick();

--- a/src/mods/timer.cpp
+++ b/src/mods/timer.cpp
@@ -2,6 +2,7 @@
 
 #include "mkb/mkb.h"
 #include "mods/freecam.h"
+#include "mods/validate.h"
 #include "systems/pref.h"
 #include "utils/draw.h"
 #include "utils/patch.h"
@@ -14,121 +15,7 @@ static u32 s_prev_retrace_count;
 static s32 s_rta_timer;
 static s32 s_pause_timer;
 
-static u32 s_framesave;
-static patch::Tramp<decltype(&mkb::did_ball_enter_goal)> s_goal_tramp;
-
-static bool line_intersects(const Vec& lineStart, const Vec& lineEnd, const mkb::Rect& rect) {
-    Vec end;
-    Vec start;
-    float half_height;
-    float half_width;
-
-    start.x = lineStart.x;
-    start.y = lineStart.y;
-    start.z = lineStart.z;
-    end.x = lineEnd.x;
-    end.y = lineEnd.y;
-    end.z = lineEnd.z;
-    mkb::mtxa_from_translate(&const_cast<Vec&>(rect.pos));
-    mkb::mtxa_rotate_z((rect.rot).z);
-    mkb::mtxa_rotate_y((rect.rot).y);
-    mkb::mtxa_rotate_x((rect.rot).x);
-    mkb::mtxa_rigid_inv_tf_point(&start, &start);
-    mkb::mtxa_rigid_inv_tf_point(&end, &end);
-    if (((end.z < 0.0) && (start.z < 0.0)) || ((0.0 < end.z && (0.0 < start.z)))) {
-        return false;
-    } else {
-        half_width = start.z - end.z;
-        if (1.192093e-07 < half_width) {
-            end.x = end.x - (start.x - end.x) * (end.z / half_width);
-            end.y = end.y - (start.y - end.y) * (end.z / half_width);
-        }
-        half_width = rect.width * 0.5;
-        half_height = rect.height * 0.5;
-        if ((end.x < -half_width) || (half_width < end.x)) {
-            return false;
-        } else if ((end.y < -half_height) || (half_height < end.y)) {
-            return false;
-        } else {
-            // update framesave if first goal entered
-            if (mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT &&
-                mkb::sub_mode != mkb::SMD_GAME_GOAL_MAIN &&
-                mkb::sub_mode != mkb::SMD_GAME_GOAL_REPLAY_INIT &&
-                mkb::sub_mode != mkb::SMD_GAME_GOAL_REPLAY_MAIN) {
-                s_framesave = static_cast<u32>((start.z / (start.z - end.z)) * 100);
-            }
-            return true;
-        }
-    }
-}
-
-void find_framesave(mkb::Ball* ball, int* out_stage_goal_idx, int* out_itemgroup_id,
-                    mkb::byte* out_goal_flags) {
-    // mostly a ghidra copy-paste
-    int itemgroup_goal_idx;
-    mkb::StagedefGoal* goal;
-    mkb::dword itemgroup_idx;
-    int stage_goal_idx;
-    mkb::StagedefColiHeader* itemgroup;
-    mkb::Rect goal_trigger;
-    mkb::PhysicsBall physicsball;
-
-    mkb::init_physicsball_from_ball(ball, &physicsball);
-    stage_goal_idx = 0;
-    itemgroup = mkb::stagedef->coli_header_list;
-    itemgroup_idx = 0;
-    do {
-        if ((int)mkb::stagedef->coli_header_count <= (int)itemgroup_idx) {
-            break;
-        }
-        if (0 < (int)itemgroup->goal_count) {
-            if (itemgroup_idx != physicsball.itemgroup_idx) {
-                mkb::tf_physball_to_itemgroup_space(&physicsball, itemgroup_idx);
-            }
-            goal = itemgroup->goal_list;
-            for (itemgroup_goal_idx = 0; itemgroup_goal_idx < (int)itemgroup->goal_count;
-                 itemgroup_goal_idx = itemgroup_goal_idx + 1) {
-                mkb::mtxa_from_translate(&goal->position);
-                mkb::mtxa_rotate_z((goal->rotation).z);
-                mkb::mtxa_rotate_y((goal->rotation).y);
-                mkb::mtxa_rotate_x((goal->rotation).x);
-                goal_trigger.pos.x = 0.0;
-                goal_trigger.pos.y = 1.5;
-                goal_trigger.pos.z = 0.0;
-                mkb::mtxa_tf_point(&goal_trigger.pos, &goal_trigger.pos);
-                goal_trigger.rot.x = (goal->rotation).x;
-                goal_trigger.rot.y = (goal->rotation).y;
-                goal_trigger.rot.z = (goal->rotation).z;
-                goal_trigger.width = 3.0;
-                goal_trigger.height = 3.0;
-                if (line_intersects(physicsball.pos, physicsball.prev_pos, goal_trigger)) {
-                    return;  // found a goal that ball travelled thru
-                }
-                stage_goal_idx = stage_goal_idx + 1;
-                goal = goal + 1;
-            }
-        }
-        itemgroup_idx = itemgroup_idx + 1;
-        itemgroup = itemgroup + 1;
-    } while (true);
-}
-
-void init() {
-    s_retrace_count = mkb::VIGetRetraceCount();
-
-    patch::hook_function(
-        s_goal_tramp, &mkb::did_ball_enter_goal,
-        [](mkb::Ball* ball, int* out_stage_goal_idx, int* out_itemgroup_id,
-           mkb::byte* out_goal_flags) {
-            bool result =
-                s_goal_tramp.dest(ball, out_stage_goal_idx, out_itemgroup_id, out_goal_flags);
-            if (result) {
-                // determine framesave percentage
-                find_framesave(ball, out_stage_goal_idx, out_itemgroup_id, out_goal_flags);
-            }
-            return result;
-        });
-}
+void init() { s_retrace_count = mkb::VIGetRetraceCount(); }
 
 // Need to do logic in disp() so that we can know the game state _after_ the frame has processed
 void disp() {
@@ -187,9 +74,11 @@ void disp() {
             return;
     }
 
+    u32 framesave = validate::get_framesave();
+
     if (pref::get(pref::BoolPref::TimerShowSubtick) && !freecam::should_hide_hud()) {
         timerdisp::draw_subtick_timer(mkb::mode_info.stage_time_frames_remaining, "SUB:", row++,
-                                      draw::WHITE, true, s_framesave, false);
+                                      draw::WHITE, true, framesave, false);
     }
 
     if (pref::get(pref::BoolPref::TimerShowUnrounded) && !freecam::should_hide_hud()) {
@@ -200,7 +89,7 @@ void disp() {
     }
 
     if (pref::get(pref::BoolPref::TimerShowFramesave) && !freecam::should_hide_hud()) {
-        timerdisp::draw_percentage(s_framesave, "FSV:", row++, draw::WHITE);
+        timerdisp::draw_percentage(framesave, "FSV:", row++, draw::WHITE);
     }
 }
 

--- a/src/mods/validate.cpp
+++ b/src/mods/validate.cpp
@@ -195,8 +195,6 @@ void init() {
 }
 
 void tick() {
-    if (mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT) {
-    }
     if (mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT) {
         s_entered_goal = false;
         s_used_mods = false;

--- a/src/mods/validate.cpp
+++ b/src/mods/validate.cpp
@@ -1,0 +1,213 @@
+#include "validate.h"
+
+#include "mods/physics.h"
+#include "systems/menu_impl.h"
+#include "systems/pad.h"
+#include "systems/pref.h"
+#include "utils/libsavest.h"
+#include "utils/macro_utils.h"
+#include "utils/patch.h"
+
+namespace validate {
+
+// calculate from did_ball_enter_goal for subtick timer
+static u32 s_framesave;
+// values for validation
+static bool s_entered_goal;
+static bool s_used_mods;
+static bool s_has_paused;
+static bool s_loaded_savestate;
+
+static patch::Tramp<decltype(&mkb::did_ball_enter_goal)> s_goal_tramp;
+
+static constexpr pref::BoolPref INVALID_BOOL_PREFS[] = {
+    pref::BoolPref::DisableFalloutVolumes,
+    pref::BoolPref::JumpMod,
+    pref::BoolPref::Marathon,
+    pref::BoolPref::DebugMode,
+};
+
+static constexpr pref::U8Pref INVALID_U8_PREFS[] = {
+    pref::U8Pref::TimerType,        pref::U8Pref::Friction,         pref::U8Pref::Restitution,
+    pref::U8Pref::FalloutPlaneType, pref::U8Pref::StageEditVariant,
+};
+
+void disable_invalidating_settings() {
+    // set all bool prefs to default
+    for (u8 i = 0; i < LEN(INVALID_BOOL_PREFS); i++) {
+        pref::set(INVALID_BOOL_PREFS[i], pref::get_default(INVALID_BOOL_PREFS[i]));
+    }
+    // set all u8 prefs to default
+    for (u8 i = 0; i < LEN(INVALID_U8_PREFS); i++) {
+        pref::set(INVALID_U8_PREFS[i], pref::get_default(INVALID_U8_PREFS[i]));
+    }
+
+    pref::save();
+}
+
+void validate_run() {
+    // Track pauses
+    bool paused_now = *reinterpret_cast<u32*>(0x805BC474) & 8;
+    if (paused_now && !s_entered_goal) {
+        s_has_paused = true;
+    }
+
+    // Track savestates
+    if (libsavest::state_loaded_this_frame()) s_loaded_savestate = true;
+
+    // Using dpad controls is disallowed
+    bool dpad_down =
+        pad::button_down(mkb::PAD_BUTTON_DOWN) || pad::button_down(mkb::PAD_BUTTON_LEFT) ||
+        pad::button_down(mkb::PAD_BUTTON_RIGHT) || pad::button_down(mkb::PAD_BUTTON_UP);
+    if (pref::get(pref::BoolPref::DpadControls) && dpad_down) s_used_mods = true;
+
+    // Opening the mod menu is disallowed
+    if (menu_impl::is_visible()) s_used_mods = true;
+
+    // Physics must be default or custom (with all default values)
+    if (physics::using_custom_physics()) s_used_mods = true;
+
+    // Invalid bool prefs are enabled
+    for (u8 i = 0; i < LEN(INVALID_BOOL_PREFS); i++) {
+        if (pref::get(INVALID_BOOL_PREFS[i]) != pref::get_default(INVALID_BOOL_PREFS[i])) {
+            s_used_mods = true;
+        }
+    }
+    // Invalid u8 prefs are enabled
+    for (u8 i = 0; i < LEN(INVALID_U8_PREFS); i++) {
+        if (pref::get(INVALID_U8_PREFS[i]) != pref::get_default(INVALID_U8_PREFS[i])) {
+            s_used_mods = true;
+        }
+    }
+}
+
+static bool line_intersects(const Vec& lineStart, const Vec& lineEnd, const mkb::Rect& rect) {
+    Vec end;
+    Vec start;
+    float half_height;
+    float half_width;
+
+    start.x = lineStart.x;
+    start.y = lineStart.y;
+    start.z = lineStart.z;
+    end.x = lineEnd.x;
+    end.y = lineEnd.y;
+    end.z = lineEnd.z;
+    mkb::mtxa_from_translate(&const_cast<Vec&>(rect.pos));
+    mkb::mtxa_rotate_z((rect.rot).z);
+    mkb::mtxa_rotate_y((rect.rot).y);
+    mkb::mtxa_rotate_x((rect.rot).x);
+    mkb::mtxa_rigid_inv_tf_point(&start, &start);
+    mkb::mtxa_rigid_inv_tf_point(&end, &end);
+    if (((end.z < 0.0) && (start.z < 0.0)) || ((0.0 < end.z && (0.0 < start.z)))) {
+        return false;
+    } else {
+        half_width = start.z - end.z;
+        if (1.192093e-07 < half_width) {
+            end.x = end.x - (start.x - end.x) * (end.z / half_width);
+            end.y = end.y - (start.y - end.y) * (end.z / half_width);
+        }
+        half_width = rect.width * 0.5;
+        half_height = rect.height * 0.5;
+        if ((end.x < -half_width) || (half_width < end.x)) {
+            return false;
+        } else if ((end.y < -half_height) || (half_height < end.y)) {
+            return false;
+        } else {
+            // update framesave if first goal entered
+            if (mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT &&
+                mkb::sub_mode != mkb::SMD_GAME_GOAL_MAIN &&
+                mkb::sub_mode != mkb::SMD_GAME_GOAL_REPLAY_INIT &&
+                mkb::sub_mode != mkb::SMD_GAME_GOAL_REPLAY_MAIN) {
+                s_framesave = static_cast<u32>((start.z / (start.z - end.z)) * 100);
+            }
+            return true;
+        }
+    }
+}
+
+void find_framesave(mkb::Ball* ball, int* out_stage_goal_idx, int* out_itemgroup_id,
+                    mkb::byte* out_goal_flags) {
+    // mostly a ghidra copy-paste
+    int itemgroup_goal_idx;
+    mkb::StagedefGoal* goal;
+    mkb::dword itemgroup_idx;
+    int stage_goal_idx;
+    mkb::StagedefColiHeader* itemgroup;
+    mkb::Rect goal_trigger;
+    mkb::PhysicsBall physicsball;
+
+    mkb::init_physicsball_from_ball(ball, &physicsball);
+    stage_goal_idx = 0;
+    itemgroup = mkb::stagedef->coli_header_list;
+    itemgroup_idx = 0;
+    do {
+        if ((int)mkb::stagedef->coli_header_count <= (int)itemgroup_idx) {
+            break;
+        }
+        if (0 < (int)itemgroup->goal_count) {
+            if (itemgroup_idx != physicsball.itemgroup_idx) {
+                mkb::tf_physball_to_itemgroup_space(&physicsball, itemgroup_idx);
+            }
+            goal = itemgroup->goal_list;
+            for (itemgroup_goal_idx = 0; itemgroup_goal_idx < (int)itemgroup->goal_count;
+                 itemgroup_goal_idx = itemgroup_goal_idx + 1) {
+                mkb::mtxa_from_translate(&goal->position);
+                mkb::mtxa_rotate_z((goal->rotation).z);
+                mkb::mtxa_rotate_y((goal->rotation).y);
+                mkb::mtxa_rotate_x((goal->rotation).x);
+                goal_trigger.pos.x = 0.0;
+                goal_trigger.pos.y = 1.5;
+                goal_trigger.pos.z = 0.0;
+                mkb::mtxa_tf_point(&goal_trigger.pos, &goal_trigger.pos);
+                goal_trigger.rot.x = (goal->rotation).x;
+                goal_trigger.rot.y = (goal->rotation).y;
+                goal_trigger.rot.z = (goal->rotation).z;
+                goal_trigger.width = 3.0;
+                goal_trigger.height = 3.0;
+                if (line_intersects(physicsball.pos, physicsball.prev_pos, goal_trigger)) {
+                    return;  // found a goal that ball travelled thru
+                }
+                stage_goal_idx = stage_goal_idx + 1;
+                goal = goal + 1;
+            }
+        }
+        itemgroup_idx = itemgroup_idx + 1;
+        itemgroup = itemgroup + 1;
+    } while (true);
+}
+
+void init() {
+    patch::hook_function(
+        s_goal_tramp, &mkb::did_ball_enter_goal,
+        [](mkb::Ball* ball, int* out_stage_goal_idx, int* out_itemgroup_id,
+           mkb::byte* out_goal_flags) {
+            bool result =
+                s_goal_tramp.dest(ball, out_stage_goal_idx, out_itemgroup_id, out_goal_flags);
+            if (result) {
+                // determine framesave percentage
+                find_framesave(ball, out_stage_goal_idx, out_itemgroup_id, out_goal_flags);
+                s_entered_goal = result;
+            }
+            return result;
+        });
+}
+
+void tick() {
+    if (mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT) {
+    }
+    if (mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT) {
+        s_entered_goal = false;
+        s_used_mods = false;
+        s_has_paused = false;
+        s_loaded_savestate = false;
+    }
+}
+
+bool was_run_valid(bool mods_allowed) {
+    return (!s_used_mods || mods_allowed) && !s_has_paused && !s_loaded_savestate && s_entered_goal;
+}
+
+u32 get_framesave() { return s_framesave; }
+
+}  // namespace validate

--- a/src/mods/validate.cpp
+++ b/src/mods/validate.cpp
@@ -81,6 +81,7 @@ void validate_run() {
     }
 }
 
+// Copy-paste of line_intersects from ghidra with slight changes to calculate s_framesave
 static bool line_intersects(const Vec& lineStart, const Vec& lineEnd, const mkb::Rect& rect) {
     Vec end;
     Vec start;
@@ -126,9 +127,9 @@ static bool line_intersects(const Vec& lineStart, const Vec& lineEnd, const mkb:
     }
 }
 
+// Copy paste from ghidra of did_ball_enter_goal with slight changes to calculate s_framesave
 void find_framesave(mkb::Ball* ball, int* out_stage_goal_idx, int* out_itemgroup_id,
                     mkb::byte* out_goal_flags) {
-    // mostly a ghidra copy-paste
     int itemgroup_goal_idx;
     mkb::StagedefGoal* goal;
     mkb::dword itemgroup_idx;

--- a/src/mods/validate.h
+++ b/src/mods/validate.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "mkb/mkb.h"
+
+namespace validate {
+
+void validate_run();
+bool was_run_valid(bool mods_allowed);
+void disable_invalidating_settings();
+u32 get_framesave();
+
+void init();
+void tick();
+
+}  // namespace validate

--- a/src/systems/main.cpp
+++ b/src/systems/main.cpp
@@ -189,16 +189,8 @@ void init() {
                 patch::hook_function(s_smd_game_play_tick_tramp, mkb::smd_game_play_tick, []() {
                     s_smd_game_play_tick_tramp.dest();
                     validate::validate_run();
-
-                    bool ilmark_valid = validate::was_run_valid(false);
-                    bool battle_valid = validate::was_run_valid(true);
-
-                    if (ilmark_valid) {
-                        ilmark::set_valid();
-                    }
-                    if (battle_valid) {
-                        ilbattle::track_valid_attempt();
-                    }
+                    ilmark::validate_attempt();
+                    ilbattle::validate_attempt();
                 });
                 jump::patch_minimap();
             }

--- a/src/systems/menu_defn.cpp
+++ b/src/systems/menu_defn.cpp
@@ -11,6 +11,7 @@
 #include "mods/physics.h"
 #include "mods/stage_edits.h"
 #include "mods/unlock.h"
+#include "mods/validate.h"
 #include "systems/pref.h"
 #include "systems/version.h"
 #include "utils/draw.h"
@@ -1220,7 +1221,7 @@ static Widget s_reset_ilmark_widgets[] = {
         .button =
             {
                 .label = "Confirm",
-                .push = [] { ilmark::disable_invalidating_settings(); },
+                .push = [] { validate::disable_invalidating_settings(); },
                 .flags = ButtonFlags::GoBack,
             },
     },


### PR DESCRIPTION
* pausing on the frame when the ball enters the goal tape no longer invalidates an IL attempt (woo!)
* unified validation from ilbattle and ilmark (in validation.cpp)
* moved framesave/subtick logic out of timer.cpp as well (to validation.cpp)

I'm going to try to get a lot of playtesting for this, I'm pretty sure the IL Mark is working fine but I want to make sure there isn't any weird behavior with IL battles (especially with the buzzer beaters)