### PR TITLE
Cardio cleanup

### DIFF
--- a/src/systems/cardio.cpp
+++ b/src/systems/cardio.cpp
@@ -146,8 +146,6 @@ static void finish_write(mkb::CARDResult res) {
 }
 
 static void tick_state_machine() {
-    mkb::CARDResult res;
-
     switch (s_state) {
         case WriteState::Idle: {
             if (!s_write_request.has_value()) {
@@ -166,7 +164,7 @@ static void tick_state_machine() {
 
         case WriteState::Probe: {
             s32 sector_size;
-            res = mkb::CARDProbeEx(0, nullptr, &sector_size);
+            mkb::CARDResult res = mkb::CARDProbeEx(0, nullptr, &sector_size);
             if (res == mkb::CARD_RESULT_BUSY) {
                 break;
             }
@@ -182,7 +180,7 @@ static void tick_state_machine() {
         }
 
         case WriteState::Mount: {
-            res = mkb::CARDGetResultCode(0);
+            mkb::CARDResult res = mkb::CARDGetResultCode(0);
             if (res == mkb::CARD_RESULT_BUSY) {
                 break;
             }
@@ -226,7 +224,7 @@ static void tick_state_machine() {
         }
 
         case WriteState::Create: {
-            res = mkb::CARDGetResultCode(0);
+            mkb::CARDResult res = mkb::CARDGetResultCode(0);
             if (res == mkb::CARD_RESULT_BUSY) {
                 break;
             }
@@ -242,7 +240,7 @@ static void tick_state_machine() {
         }
 
         case WriteState::Delete: {
-            res = mkb::CARDGetResultCode(0);
+            mkb::CARDResult res = mkb::CARDGetResultCode(0);
             if (res == mkb::CARD_RESULT_BUSY) {
                 break;
             }
@@ -257,7 +255,7 @@ static void tick_state_machine() {
         }
 
         case WriteState::Write: {
-            res = mkb::CARDGetResultCode(0);
+            mkb::CARDResult res = mkb::CARDGetResultCode(0);
             if (res != mkb::CARD_RESULT_BUSY) {
                 // Either succeeded or failed, either way we're done
                 finish_write(res);
@@ -268,7 +266,7 @@ static void tick_state_machine() {
 }
 
 void tick() {
-    WriteState prev_state;
+    WriteState prev_state = WriteState::Idle;
     do {
         prev_state = s_state;
         tick_state_machine();

--- a/src/systems/cardio.cpp
+++ b/src/systems/cardio.cpp
@@ -145,7 +145,7 @@ static void finish_write(mkb::CARDResult res) {
     restore_original_gamecode();
 }
 
-void tick() {
+static void tick_state_machine() {
     mkb::CARDResult res;
 
     switch (s_state) {
@@ -265,6 +265,14 @@ void tick() {
             break;
         }
     }
+}
+
+void tick() {
+    WriteState prev_state;
+    do {
+        prev_state = s_state;
+        tick_state_machine();
+    } while (prev_state != s_state);
 }
 
 }  // namespace cardio


### PR DESCRIPTION
* Cleanup conditionals
* Properly wait for `CARDProbeEx()` to finish before proceeding
* Allow transitioning between more than one state on the same frame. This might decrease the number of frames it takes to save, but at the very least it should prevent the new `Probe` state from costing an additional frame

Pushed this while v tired so might be super bugged