### PR TITLE
Migrate from RefCell-based state sharing to Cell-based

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,7 +144,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings
+# Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 #*.pubxml
 *.publishproj

--- a/crates/mkb/src/lib.rs
+++ b/crates/mkb/src/lib.rs
@@ -4,5 +4,6 @@
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]
+#[allow(clippy::missing_safety_doc)]
 pub mod mkb;
 pub mod mkb_suppl;

--- a/crates/mkb/src/mkb_suppl.rs
+++ b/crates/mkb/src/mkb_suppl.rs
@@ -85,6 +85,6 @@ impl From<mkb::GXColor> for u32 {
         ((color.a as u32) << 24)
             | ((color.r as u32) << 16)
             | ((color.g as u32) << 8)
-            | ((color.b as u32) << 0)
+            | (color.b as u32)
     }
 }

--- a/crates/smb2_practice_mod/Cargo.toml
+++ b/crates/smb2_practice_mod/Cargo.toml
@@ -20,4 +20,5 @@ test = false
 bench = false
 
 [lints.rust]
+# Currently needed to suppress weird zerocopy warning on nightly
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/smb2_practice_mod/Cargo.toml
+++ b/crates/smb2_practice_mod/Cargo.toml
@@ -18,3 +18,6 @@ mkb = { path = "../mkb" }
 crate-type = ["staticlib"]
 test = false
 bench = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/crates/smb2_practice_mod/src/app.rs
+++ b/crates/smb2_practice_mod/src/app.rs
@@ -1,6 +1,6 @@
 use core::cell::RefCell;
 
-use critical_section::{CriticalSection, Mutex};
+use critical_section::Mutex;
 use mkb::mkb;
 use once_cell::sync::Lazy;
 
@@ -16,152 +16,165 @@ use crate::{
     systems::{
         binds::Binds,
         draw::Draw,
+        menu_defn::MenuContext,
         menu_impl::MenuImpl,
         pad::Pad,
         pref::{BoolPref, Pref},
     },
-    utils::{libsavestate::LibSaveState, relutil::ModuleId},
+    utils::{libsavestate::LibSaveState, misc::with_mutex, relutil::ModuleId},
 };
 
-pub static APP_CONTEXT: once_cell::sync::Lazy<critical_section::Mutex<AppContext>> =
-    once_cell::sync::Lazy::new(|| critical_section::Mutex::new(AppContext::new()));
+static APP_CONTEXT: Lazy<Mutex<RefCell<AppContext>>> =
+    Lazy::new(|| Mutex::new(RefCell::new(AppContext::new())));
+
+pub fn with_app<T>(f: impl FnOnce(&mut AppContext) -> T) -> T {
+    critical_section::with(|cs| f(&mut APP_CONTEXT.borrow_ref_mut(cs)))
+}
 
 #[derive(Default)]
-struct AppContext {
+struct Globals {
     process_inputs_hook: ProcessInputsHook,
     draw_debug_text_hook: DrawDebugTextHook,
     oslink_hook: OSLinkHook,
     game_ready_init_hook: GameReadyInitHook,
     game_play_tick_hook: GamePlayTickHook,
+}
 
-    pad: Pad,
-    binds: Binds,
-    menu_impl: MenuImpl,
-    unlock: Unlock,
-    iw: Iw,
-    lib_save_state: LibSaveState,
-    save_states_ui: SaveStatesUi,
-    fallout: Fallout,
-    jump: Jump,
-    physics: Physics,
-    input_display: InputDisplay,
-    go_to_story: GoToStory,
-    cm_seg: CmSeg,
-    banans: Banans,
-    marathon: Marathon,
-    ball_color: BallColor,
-    freecam: Freecam,
-    timer: Timer,
-    dpad: Dpad,
-    il_battle: IlBattle,
-    il_mark: IlMark,
-    camera: Camera,
-    stage_edits: StageEdits,
-    hide: Hide,
-    sfx: Sfx,
-    scratch: Scratch,
-    validate: Validate,
-    draw: Draw,
-    pref: Pref,
+static GLOBALS: Lazy<Mutex<Globals>> = Lazy::new(|| Mutex::new(Globals::default()));
+
+#[derive(Default)]
+pub struct AppContext {
+    pub pad: Pad,
+    pub binds: Binds,
+    pub menu_impl: MenuImpl,
+    pub unlock: Unlock,
+    pub iw: Iw,
+    pub lib_save_state: LibSaveState,
+    pub save_states_ui: SaveStatesUi,
+    pub fallout: Fallout,
+    pub jump: Jump,
+    pub physics: Physics,
+    pub input_display: InputDisplay,
+    pub go_to_story: GoToStory,
+    pub cm_seg: CmSeg,
+    pub banans: Banans,
+    pub marathon: Marathon,
+    pub ball_color: BallColor,
+    pub freecam: Freecam,
+    pub timer: Timer,
+    pub dpad: Dpad,
+    pub il_battle: IlBattle,
+    pub il_mark: IlMark,
+    pub camera: Camera,
+    pub stage_edits: StageEdits,
+    pub hide: Hide,
+    pub sfx: Sfx,
+    pub scratch: Scratch,
+    pub validate: Validate,
+    pub draw: Draw,
+    pub pref: Pref,
 }
 
 impl AppContext {
     fn new() -> Self {
         crate::systems::heap::HEAP.init();
-        Self::default()
-    }
-
-    fn init(&mut self) {
-        self.process_inputs_hook.hook();
-        self.draw_debug_text_hook.hook();
-        self.oslink_hook.hook();
-
-        self.pad.on_main_loop_load();
-        self.lib_save_state.on_main_loop_load();
-        self.save_states_ui.on_main_loop_load();
-        self.fallout.on_main_loop_load();
-        self.cm_seg.on_main_loop_load();
-        self.ball_color.on_main_loop_load();
-        self.freecam.on_main_loop_load();
-        self.dpad.on_main_loop_load();
-        self.stage_edits.on_main_loop_load();
-        self.hide.on_main_loop_load();
-        with_global_cx(|gcx| {
-            self.sfx.on_main_loop_load(gcx);
+        with_mutex(&GLOBALS, |cx| {
+            cx.process_inputs_hook.hook();
+            cx.draw_debug_text_hook.hook();
+            cx.oslink_hook.hook();
         });
-        self.validate.on_main_loop_load();
+
+        Self::default()
     }
 }
 
 // Tick functions hook
 hook!(ProcessInputsHook => (), mkb::process_inputs, || {
-    critical_section::with(|cs| {
-        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
-
+    with_mutex(&GLOBALS, |cx| {
         cx.process_inputs_hook.call();
+    });
 
-        with_global_cx(|gcx| {
-            cx.pad.tick();
-            cx.binds.tick(&mut cx.pad);
-            cx.unlock.tick(cx);
-            cx.iw.tick(cx);
-            cx.save_states_ui.tick(cx);
-            cx.menu_impl.tick(cx);
-            cx.fallout.tick(cx);
-            cx.jump.tick(cx);
-            cx.physics.tick(cx);
-            cx.input_display.tick(cx);
-            cx.go_to_story.tick(cx);
-            cx.cm_seg.tick(cx);
-            cx.banans.tick(cx);
-            cx.marathon.tick(cx);
-            cx.ball_color.tick(gcx);
-            cx.freecam.tick(cx);
-            cx.il_battle.tick(cx);
-            cx.il_mark.tick(cx);
-            cx.camera.tick(cx);
-            cx.stage_edits.tick(cx);
-            cx.validate.tick(cx);
-            cx.scratch.tick(cx);
-            cx.pref.tick(cx);
-        })
+    with_app(|cx| {
+        cx.pad.tick();
+        cx.binds.tick(&cx.pad);
+        cx.unlock.tick(&cx.pref);
+        cx.iw.tick(&cx.pad);
+        cx.save_states_ui.tick(&cx.pref, &cx.pad, &mut cx.draw, &cx.binds, &mut cx.lib_save_state, &mut cx.timer);
+        let mut menu_context = MenuContext {
+            pad: &mut cx.pad,
+            pref: &mut cx.pref,
+            draw: &mut cx.draw,
+            binds: &mut cx.binds,
+            cm_seg: &mut cx.cm_seg,
+            go_to_story: &mut cx.go_to_story,
+            stage_edits: &mut cx.stage_edits,
+            unlock: &mut cx.unlock,
+        };
+        cx.menu_impl.tick(&mut menu_context);
+        cx.fallout.tick(&cx.pref, &cx.freecam);
+        cx.jump.tick(&mut cx.pref, &cx.pad);
+        cx.physics.tick(&cx.pref, &cx.freecam);
+        cx.input_display.tick(&cx.pref);
+        cx.go_to_story.tick();
+        cx.cm_seg.tick(&cx.pref);
+        cx.banans.tick(&cx.pref);
+        cx.marathon.tick(&cx.pref);
+        cx.ball_color.tick(&cx.pref);
+        cx.freecam.tick(&mut cx.pref, &cx.pad, &mut cx.draw, &cx.binds);
+        cx.il_battle.tick(&cx.pref, &cx.freecam, &cx.binds, &cx.pad);
+        cx.il_mark.tick(&cx.lib_save_state);
+        cx.camera.tick(&cx.pref);
+        cx.stage_edits.tick();
+        cx.validate.tick();
+        cx.scratch.tick();
+        cx.pref.tick(&mut cx.draw);
     });
 });
 
 // Draw functions hook
 hook!(DrawDebugTextHook => (), mkb::draw_debugtext, || {
-    critical_section::with(|cs| {
-        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
-
+    with_mutex(&GLOBALS, |cx| {
         cx.draw_debug_text_hook.call();
+    });
 
-        // When the game is paused, screenshot the game's draw buffer before we draw our custom UI
-        // elements. The original screenshot call is nopped.
-        unsafe {
-            if mkb::g_pause_status == 1 {
-                mkb::take_pausemenu_screenshot(
-                    &raw mut mkb::fullscreen_texture_buf as *mut _,
-                    0,
-                    0,
-                    (*mkb::current_render_mode).fbWidth as i16,
-                    (*mkb::current_render_mode).efbHeight as i16,
-                    mkb::GX_TF_RGB5A3,
-                );
-            }
-        };
+    // When the game is paused, screenshot the game's draw buffer before we draw our custom UI
+    // elements. The original screenshot call is nopped.
+    unsafe {
+        if mkb::g_pause_status == 1 {
+            mkb::take_pausemenu_screenshot(
+                &raw mut mkb::fullscreen_texture_buf as *mut _,
+                0,
+                0,
+                (*mkb::current_render_mode).fbWidth as i16,
+                (*mkb::current_render_mode).efbHeight as i16,
+                mkb::GX_TF_RGB5A3,
+            );
+        }
+    };
 
+    with_app(|cx| {
         cx.draw.predraw();
 
-        cx.timer.draw(cx);
-        cx.iw.draw(cx);
-        cx.il_battle.draw(cx);
-        cx.cm_seg.draw(cx);
-        cx.input_display.draw(cx);
-        cx.menu_impl.draw(cx);
-        cx.draw.draw(cx);
-        cx.il_mark.draw(cx);
-        cx.physics.draw(cx);
-        cx.scratch.draw(cx);
+        cx.timer.draw(&cx.pref, &cx.freecam, &cx.validate);
+        cx.iw.draw(&cx.pref, &cx.freecam);
+        cx.il_battle.draw(&cx.pref, &cx.freecam, &cx.binds, &cx.pad);
+        cx.cm_seg.draw(&cx.pref, &cx.freecam);
+        cx.input_display.draw(&cx.pref, &cx.pad, &cx.freecam, &cx.ball_color);
+        let mut menu_context = MenuContext {
+            pad: &mut cx.pad,
+            pref: &mut cx.pref,
+            draw: &mut cx.draw,
+            binds: &mut cx.binds,
+            cm_seg: &mut cx.cm_seg,
+            go_to_story: &mut cx.go_to_story,
+            stage_edits: &mut cx.stage_edits,
+            unlock: &mut cx.unlock,
+        };
+        cx.menu_impl.draw(&mut menu_context);
+        cx.draw.draw();
+        cx.il_mark.draw(&cx.pref, &cx.freecam);
+        cx.physics.draw(&cx.pref, &cx.freecam);
+        cx.scratch.draw();
     });
 });
 
@@ -172,52 +185,42 @@ hook!(OSLinkHook,
         mkb::OSLink,
         |rel_buffer, bss_buffer| {
 
-    critical_section::with(|cs| {
-        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
-
+    with_mutex(&GLOBALS, |cx| {
         let ret = cx.oslink_hook.call(rel_buffer, bss_buffer);
-
         let module_id = ModuleId::try_from(unsafe{*rel_buffer}.info.id);
         if let Ok(ModuleId::MainGame) = module_id {
             cx.game_ready_init_hook.hook();
             cx.game_play_tick_hook.hook();
         }
-
         ret
     })
 });
 
 hook!(GameReadyInitHook => (), mkb::smd_game_ready_init, || {
-    critical_section::with(|cs| {
-        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
+    with_app(|cx| {
+        cx.stage_edits.on_game_ready_init(&cx.pref);
+        cx.ball_color.switch_monkey(&cx.pref);
+    });
 
-        cx.stage_edits.on_game_ready_init(cx);
-        with_global_cx(|gcx| {
-            BallColor::switch_monkey(gcx);
-        });
+    with_mutex(&GLOBALS, |cx| {
         cx.game_ready_init_hook.call();
     });
 });
 
 hook!(GamePlayTickHook => (), mkb::smd_game_play_tick, || {
-    critical_section::with(|cs| {
-        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
-
+    with_mutex(&GLOBALS, |cx| {
         cx.game_play_tick_hook.call();
+    });
 
-        with_global_cx(|gcx| {
-            cx.validate.validate_run(gcx, &cx.lib_save_state, &cx.menu_impl, &cx.physics, &cx.pad);
-        });
-
+    with_app(|cx| {
+        cx.validate.validate_run(&cx.pref, &cx.lib_save_state, &cx.menu_impl, &cx.physics, &cx.pad);
         cx.il_mark.validate_attempt(&cx.validate);
-        cx.il_battle.validate_attempt(&cx.validate);
+        cx.il_battle.validate_attempt(&mut cx.validate);
     });
 });
 
 pub fn init() {
-    critical_section::with(|cs| {
-        APP_CONTEXT.borrow_ref_mut(cs).init();
-    });
+    with_app(|_| {});
 }
 
 pub fn tick() {
@@ -225,17 +228,12 @@ pub fn tick() {
         // Replace overwritten function call
         mkb::perf_init_timer(4);
 
-        with_global_cx(|cx| {
+        with_app(|cx| {
             if cx.pref.get_bool(BoolPref::DebugMode) {
                 mkb::dip_switches |= mkb::DIP_DEBUG | mkb::DIP_DISP;
             } else {
                 mkb::dip_switches &= !(mkb::DIP_DEBUG | mkb::DIP_DISP);
             }
-        });
-
-        critical_section::with(|cs| {
-            let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
-
             cx.pad.on_frame_start();
         });
     }

--- a/crates/smb2_practice_mod/src/app.rs
+++ b/crates/smb2_practice_mod/src/app.rs
@@ -1,6 +1,8 @@
 use core::cell::RefCell;
 
+use critical_section::{CriticalSection, Mutex};
 use mkb::mkb;
+use once_cell::sync::Lazy;
 
 use crate::{
     hook,
@@ -36,46 +38,46 @@ where
     critical_section::with(|cs| f(GLOBAL_CONTEXT.borrow(cs)))
 }
 
-pub static APP_CONTEXT: once_cell::sync::Lazy<critical_section::Mutex<AppContext>> =
-    once_cell::sync::Lazy::new(|| critical_section::Mutex::new(AppContext::new()));
+static APP_CONTEXT: Lazy<Mutex<RefCell<AppContext>>> =
+    Lazy::new(|| Mutex::new(RefCell::new(AppContext::new())));
 
 #[derive(Default)]
-pub struct AppContext {
-    pub process_inputs_hook: RefCell<ProcessInputsHook>,
-    pub draw_debug_text_hook: RefCell<DrawDebugTextHook>,
-    pub oslink_hook: RefCell<OSLinkHook>,
-    pub game_ready_init_hook: RefCell<GameReadyInitHook>,
-    pub game_play_tick_hook: RefCell<GamePlayTickHook>,
+struct AppContext {
+    process_inputs_hook: ProcessInputsHook,
+    draw_debug_text_hook: DrawDebugTextHook,
+    oslink_hook: OSLinkHook,
+    game_ready_init_hook: GameReadyInitHook,
+    game_play_tick_hook: GamePlayTickHook,
 
-    pub pad: RefCell<Pad>,
-    pub binds: RefCell<Binds>,
-    pub menu_impl: RefCell<MenuImpl>,
-    pub unlock: RefCell<Unlock>,
-    pub iw: RefCell<Iw>,
-    pub lib_save_state: RefCell<LibSaveState>,
-    pub save_states_ui: RefCell<SaveStatesUi>,
-    pub fallout: RefCell<Fallout>,
-    pub jump: RefCell<Jump>,
-    pub physics: RefCell<Physics>,
-    pub input_display: RefCell<InputDisplay>,
-    pub go_to_story: RefCell<GoToStory>,
-    pub cm_seg: RefCell<CmSeg>,
-    pub banans: RefCell<Banans>,
-    pub marathon: RefCell<Marathon>,
-    pub ball_color: RefCell<BallColor>,
-    pub freecam: RefCell<Freecam>,
-    pub timer: RefCell<Timer>,
-    pub dpad: RefCell<Dpad>,
-    pub il_battle: RefCell<IlBattle>,
-    pub il_mark: RefCell<IlMark>,
-    pub camera: RefCell<Camera>,
-    pub stage_edits: RefCell<StageEdits>,
-    pub hide: RefCell<Hide>,
-    pub sfx: RefCell<Sfx>,
-    pub scratch: RefCell<Scratch>,
-    pub validate: RefCell<Validate>,
-    pub draw: RefCell<Draw>,
-    pub pref: RefCell<Pref>,
+    pad: Pad,
+    binds: Binds,
+    menu_impl: MenuImpl,
+    unlock: Unlock,
+    iw: Iw,
+    lib_save_state: LibSaveState,
+    save_states_ui: SaveStatesUi,
+    fallout: Fallout,
+    jump: Jump,
+    physics: Physics,
+    input_display: InputDisplay,
+    go_to_story: GoToStory,
+    cm_seg: CmSeg,
+    banans: Banans,
+    marathon: Marathon,
+    ball_color: BallColor,
+    freecam: Freecam,
+    timer: Timer,
+    dpad: Dpad,
+    il_battle: IlBattle,
+    il_mark: IlMark,
+    camera: Camera,
+    stage_edits: StageEdits,
+    hide: Hide,
+    sfx: Sfx,
+    scratch: Scratch,
+    validate: Validate,
+    draw: Draw,
+    pref: Pref,
 }
 
 impl AppContext {
@@ -84,86 +86,98 @@ impl AppContext {
         Self::default()
     }
 
-    fn init(&self) {
-        self.process_inputs_hook.borrow_mut().hook();
-        self.draw_debug_text_hook.borrow_mut().hook();
-        self.oslink_hook.borrow_mut().hook();
+    fn init(&mut self) {
+        self.process_inputs_hook.hook();
+        self.draw_debug_text_hook.hook();
+        self.oslink_hook.hook();
 
-        self.pad.borrow_mut().on_main_loop_load(self);
-        self.lib_save_state.borrow_mut().on_main_loop_load(self);
-        self.save_states_ui.borrow_mut().on_main_loop_load(self);
-        self.fallout.borrow_mut().on_main_loop_load(self);
-        self.cm_seg.borrow_mut().on_main_loop_load(self);
-        self.ball_color.borrow_mut().on_main_loop_load(self);
-        self.freecam.borrow_mut().on_main_loop_load(self);
-        self.dpad.borrow_mut().on_main_loop_load(self);
-        self.stage_edits.borrow_mut().on_main_loop_load(self);
-        self.hide.borrow_mut().on_main_loop_load(self);
-        self.sfx.borrow_mut().on_main_loop_load(self);
-        self.validate.borrow_mut().on_main_loop_load(self);
+        self.pad.on_main_loop_load();
+        self.lib_save_state.on_main_loop_load();
+        self.save_states_ui.on_main_loop_load();
+        self.fallout.on_main_loop_load();
+        self.cm_seg.on_main_loop_load();
+        self.ball_color.on_main_loop_load();
+        self.freecam.on_main_loop_load();
+        self.dpad.on_main_loop_load();
+        self.stage_edits.on_main_loop_load();
+        self.hide.on_main_loop_load();
+        with_global_cx(|gcx| {
+            self.sfx.on_main_loop_load(gcx);
+        });
+        self.validate.on_main_loop_load();
     }
 }
 
 // Tick functions hook
-hook!(ProcessInputsHook => (), mkb::process_inputs, |cx| {
-    cx.process_inputs_hook.borrow().call();
+hook!(ProcessInputsHook => (), mkb::process_inputs, || {
+    critical_section::with(|cs| {
+        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
 
-    cx.pad.borrow_mut().tick(cx);
-    cx.binds.borrow_mut().tick(cx);
-    cx.unlock.borrow_mut().tick(cx);
-    cx.iw.borrow_mut().tick(cx);
-    cx.save_states_ui.borrow_mut().tick(cx);
-    cx.menu_impl.borrow_mut().tick(cx);
-    cx.fallout.borrow_mut().tick(cx);
-    cx.jump.borrow_mut().tick(cx);
-    cx.physics.borrow_mut().tick(cx);
-    cx.input_display.borrow_mut().tick(cx);
-    cx.go_to_story.borrow_mut().tick(cx);
-    cx.cm_seg.borrow_mut().tick(cx);
-    cx.banans.borrow_mut().tick(cx);
-    cx.marathon.borrow_mut().tick(cx);
-    cx.ball_color.borrow_mut().tick(cx);
-    cx.freecam.borrow_mut().tick(cx);
-    cx.il_battle.borrow_mut().tick(cx);
-    cx.il_mark.borrow_mut().tick(cx);
-    cx.camera.borrow_mut().tick(cx);
-    cx.stage_edits.borrow_mut().tick(cx);
-    cx.validate.borrow_mut().tick(cx);
-    cx.scratch.borrow_mut().tick(cx);
-    cx.pref.borrow_mut().tick(cx);
+        cx.process_inputs_hook.call();
+
+        with_global_cx(|gcx| {
+            cx.pad.tick();
+            cx.binds.tick(&mut cx.pad);
+            cx.unlock.tick(cx);
+            cx.iw.tick(cx);
+            cx.save_states_ui.tick(cx);
+            cx.menu_impl.tick(cx);
+            cx.fallout.tick(cx);
+            cx.jump.tick(cx);
+            cx.physics.tick(cx);
+            cx.input_display.tick(cx);
+            cx.go_to_story.tick(cx);
+            cx.cm_seg.tick(cx);
+            cx.banans.tick(cx);
+            cx.marathon.tick(cx);
+            cx.ball_color.tick(gcx);
+            cx.freecam.tick(cx);
+            cx.il_battle.tick(cx);
+            cx.il_mark.tick(cx);
+            cx.camera.tick(cx);
+            cx.stage_edits.tick(cx);
+            cx.validate.tick(cx);
+            cx.scratch.tick(cx);
+            cx.pref.tick(cx);
+        })
+    });
 });
 
 // Draw functions hook
-hook!(DrawDebugTextHook => (), mkb::draw_debugtext, |cx| {
-    cx.draw_debug_text_hook.borrow().call();
+hook!(DrawDebugTextHook => (), mkb::draw_debugtext, || {
+    critical_section::with(|cs| {
+        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
 
-    // When the game is paused, screenshot the game's draw buffer before we draw our custom UI
-    // elements. The original screenshot call is nopped.
-    unsafe {
-        if mkb::g_pause_status == 1 {
-            mkb::take_pausemenu_screenshot(
-                &raw mut mkb::fullscreen_texture_buf as *mut _,
-                0,
-                0,
-                (*mkb::current_render_mode).fbWidth as i16,
-                (*mkb::current_render_mode).efbHeight as i16,
-                mkb::GX_TF_RGB5A3,
-            );
-        }
-    };
+        cx.draw_debug_text_hook.call();
 
-    cx.draw.borrow().predraw();
+        // When the game is paused, screenshot the game's draw buffer before we draw our custom UI
+        // elements. The original screenshot call is nopped.
+        unsafe {
+            if mkb::g_pause_status == 1 {
+                mkb::take_pausemenu_screenshot(
+                    &raw mut mkb::fullscreen_texture_buf as *mut _,
+                    0,
+                    0,
+                    (*mkb::current_render_mode).fbWidth as i16,
+                    (*mkb::current_render_mode).efbHeight as i16,
+                    mkb::GX_TF_RGB5A3,
+                );
+            }
+        };
 
-    cx.timer.borrow_mut().draw(cx);
-    cx.iw.borrow_mut().draw(cx);
-    cx.il_battle.borrow_mut().draw(cx);
-    cx.cm_seg.borrow_mut().draw(cx);
-    cx.input_display.borrow_mut().draw(cx);
-    cx.menu_impl.borrow_mut().draw(cx);
-    cx.draw.borrow_mut().draw(cx);
-    cx.il_mark.borrow_mut().draw(cx);
-    cx.physics.borrow_mut().draw(cx);
-    cx.scratch.borrow_mut().draw(cx);
+        cx.draw.predraw();
+
+        cx.timer.draw(cx);
+        cx.iw.draw(cx);
+        cx.il_battle.draw(cx);
+        cx.cm_seg.draw(cx);
+        cx.input_display.draw(cx);
+        cx.menu_impl.draw(cx);
+        cx.draw.draw(cx);
+        cx.il_mark.draw(cx);
+        cx.physics.draw(cx);
+        cx.scratch.draw(cx);
+    });
 });
 
 // MainGameLoad calls
@@ -171,42 +185,53 @@ hook!(OSLinkHook,
         rel_buffer: *mut mkb::OSModuleHeader,
         bss_buffer: *mut core::ffi::c_void => u8,
         mkb::OSLink,
-        |rel_buffer, bss_buffer, cx| {
-    let ret = cx.oslink_hook.borrow().call(rel_buffer, bss_buffer);
+        |rel_buffer, bss_buffer| {
 
-    let module_id = ModuleId::try_from(unsafe{*rel_buffer}.info.id);
-    if let Ok(ModuleId::MainGame) = module_id {
-        cx.game_ready_init_hook.borrow_mut().hook();
-        cx.game_play_tick_hook.borrow_mut().hook();
-    }
+    critical_section::with(|cs| {
+        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
 
-    ret
+        let ret = cx.oslink_hook.call(rel_buffer, bss_buffer);
+
+        let module_id = ModuleId::try_from(unsafe{*rel_buffer}.info.id);
+        if let Ok(ModuleId::MainGame) = module_id {
+            cx.game_ready_init_hook.hook();
+            cx.game_play_tick_hook.hook();
+        }
+
+        ret
+    })
 });
 
-hook!(GameReadyInitHook => (), mkb::smd_game_ready_init, |cx| {
-    cx.stage_edits.borrow_mut().on_game_ready_init(cx);
-    cx.ball_color.borrow_mut().switch_monkey(&mut cx.pref.borrow_mut());
-    cx.game_ready_init_hook.borrow().call();
+hook!(GameReadyInitHook => (), mkb::smd_game_ready_init, || {
+    critical_section::with(|cs| {
+        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
+
+        cx.stage_edits.on_game_ready_init(cx);
+        with_global_cx(|gcx| {
+            BallColor::switch_monkey(gcx);
+        });
+        cx.game_ready_init_hook.call();
+    });
 });
 
-hook!(GamePlayTickHook => (), mkb::smd_game_play_tick, |cx| {
-    cx.game_play_tick_hook.borrow().call();
+hook!(GamePlayTickHook => (), mkb::smd_game_play_tick, || {
+    critical_section::with(|cs| {
+        let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
 
-    let validate = &mut cx.validate.borrow_mut();
-    let pref = &mut cx.pref.borrow_mut();
-    let lib_save_state = &mut cx.lib_save_state.borrow_mut();
-    let menu_impl = &mut cx.menu_impl.borrow_mut();
-    let physics = &mut cx.physics.borrow_mut();
-    let pad = &mut cx.pad.borrow_mut();
+        cx.game_play_tick_hook.call();
 
-    validate.validate_run(pref, lib_save_state, menu_impl, physics, pad);
-    cx.il_mark.borrow_mut().validate_attempt(validate);
-    cx.il_battle.borrow_mut().validate_attempt(validate);
+        with_global_cx(|gcx| {
+            cx.validate.validate_run(gcx, &cx.lib_save_state, &cx.menu_impl, &cx.physics, &cx.pad);
+        });
+
+        cx.il_mark.validate_attempt(&cx.validate);
+        cx.il_battle.validate_attempt(&cx.validate);
+    });
 });
 
 pub fn init() {
     critical_section::with(|cs| {
-        APP_CONTEXT.borrow(cs).init();
+        APP_CONTEXT.borrow_ref_mut(cs).init();
     });
 }
 
@@ -215,16 +240,18 @@ pub fn tick() {
         // Replace overwritten function call
         mkb::perf_init_timer(4);
 
-        critical_section::with(|cs| {
-            let cx = APP_CONTEXT.borrow(cs);
-            let pref = cx.pref.borrow_mut();
-            if pref.get_bool(BoolPref::DebugMode) {
+        with_global_cx(|cx| {
+            if cx.pref.get_bool(BoolPref::DebugMode) {
                 mkb::dip_switches |= mkb::DIP_DEBUG | mkb::DIP_DISP;
             } else {
                 mkb::dip_switches &= !(mkb::DIP_DEBUG | mkb::DIP_DISP);
             }
+        });
 
-            cx.pad.borrow_mut().on_frame_start();
+        critical_section::with(|cs| {
+            let cx = &mut APP_CONTEXT.borrow_ref_mut(cs);
+
+            cx.pad.on_frame_start();
         });
     }
 }

--- a/crates/smb2_practice_mod/src/app.rs
+++ b/crates/smb2_practice_mod/src/app.rs
@@ -67,7 +67,7 @@ pub struct AppContext {
     pub il_mark: IlMark,
     pub camera: Camera,
     pub stage_edits: StageEdits,
-    pub hide: Hide,
+    pub _hide: Hide,
     pub sfx: Sfx,
     pub scratch: Scratch,
     pub validate: Validate,
@@ -99,7 +99,7 @@ hook!(ProcessInputsHook => (), mkb::process_inputs, || {
         cx.binds.tick(&cx.pad);
         cx.unlock.tick(&cx.pref);
         cx.iw.tick(&cx.pad);
-        cx.save_states_ui.tick(&cx.pref, &cx.pad, &mut cx.draw, &cx.binds, &mut cx.lib_save_state, &mut cx.timer);
+        cx.save_states_ui.tick(&cx.pref, &cx.pad, &mut cx.draw, &cx.binds, &mut cx.timer);
         let mut menu_context = MenuContext {
             pad: &mut cx.pad,
             pref: &mut cx.pref,
@@ -126,6 +126,7 @@ hook!(ProcessInputsHook => (), mkb::process_inputs, || {
         cx.camera.tick(&cx.pref);
         cx.stage_edits.tick();
         cx.validate.tick();
+        cx.sfx.tick(&cx.pref);
         cx.scratch.tick();
         cx.pref.tick(&mut cx.draw);
     });

--- a/crates/smb2_practice_mod/src/app.rs
+++ b/crates/smb2_practice_mod/src/app.rs
@@ -18,28 +18,13 @@ use crate::{
         draw::Draw,
         menu_impl::MenuImpl,
         pad::Pad,
-        pref::{BoolPref, Pref, PrefDb},
+        pref::{BoolPref, Pref},
     },
     utils::{libsavestate::LibSaveState, relutil::ModuleId},
 };
 
-#[derive(Default)]
-pub struct GlobalContext {
-    pub pref: PrefDb,
-}
-
-pub static GLOBAL_CONTEXT: once_cell::sync::Lazy<critical_section::Mutex<GlobalContext>> =
-    once_cell::sync::Lazy::new(|| critical_section::Mutex::new(GlobalContext::default()));
-
-pub fn with_global_cx<F, R>(f: F) -> R
-where
-    F: FnOnce(&GlobalContext) -> R,
-{
-    critical_section::with(|cs| f(GLOBAL_CONTEXT.borrow(cs)))
-}
-
-static APP_CONTEXT: Lazy<Mutex<RefCell<AppContext>>> =
-    Lazy::new(|| Mutex::new(RefCell::new(AppContext::new())));
+pub static APP_CONTEXT: once_cell::sync::Lazy<critical_section::Mutex<AppContext>> =
+    once_cell::sync::Lazy::new(|| critical_section::Mutex::new(AppContext::new()));
 
 #[derive(Default)]
 struct AppContext {

--- a/crates/smb2_practice_mod/src/app.rs
+++ b/crates/smb2_practice_mod/src/app.rs
@@ -31,7 +31,6 @@ pub fn with_app<T>(f: impl FnOnce(&mut AppContext) -> T) -> T {
     critical_section::with(|cs| f(&mut APP_CONTEXT.borrow_ref_mut(cs)))
 }
 
-#[derive(Default)]
 struct Globals {
     process_inputs_hook: ProcessInputsHook,
     draw_debug_text_hook: DrawDebugTextHook,
@@ -40,7 +39,13 @@ struct Globals {
     game_play_tick_hook: GamePlayTickHook,
 }
 
-static GLOBALS: Lazy<Mutex<Globals>> = Lazy::new(|| Mutex::new(Globals::default()));
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    process_inputs_hook: ProcessInputsHook::new(),
+    draw_debug_text_hook: DrawDebugTextHook::new(),
+    oslink_hook: OSLinkHook::new(),
+    game_ready_init_hook: GameReadyInitHook::new(),
+    game_play_tick_hook: GamePlayTickHook::new(),
+});
 
 #[derive(Default)]
 pub struct AppContext {

--- a/crates/smb2_practice_mod/src/app.rs
+++ b/crates/smb2_practice_mod/src/app.rs
@@ -16,10 +16,25 @@ use crate::{
         draw::Draw,
         menu_impl::MenuImpl,
         pad::Pad,
-        pref::{BoolPref, Pref},
+        pref::{BoolPref, Pref, PrefDb},
     },
     utils::{libsavestate::LibSaveState, relutil::ModuleId},
 };
+
+#[derive(Default)]
+pub struct GlobalContext {
+    pub pref: PrefDb,
+}
+
+pub static GLOBAL_CONTEXT: once_cell::sync::Lazy<critical_section::Mutex<GlobalContext>> =
+    once_cell::sync::Lazy::new(|| critical_section::Mutex::new(GlobalContext::default()));
+
+pub fn with_global_cx<F, R>(f: F) -> R
+where
+    F: FnOnce(&GlobalContext) -> R,
+{
+    critical_section::with(|cs| f(GLOBAL_CONTEXT.borrow(cs)))
+}
 
 pub static APP_CONTEXT: once_cell::sync::Lazy<critical_section::Mutex<AppContext>> =
     once_cell::sync::Lazy::new(|| critical_section::Mutex::new(AppContext::new()));

--- a/crates/smb2_practice_mod/src/lib.rs
+++ b/crates/smb2_practice_mod/src/lib.rs
@@ -13,14 +13,18 @@ mod utils;
 
 use crate::utils::patch;
 
+#[cfg(target_arch = "powerpc")]
+use core::panic::PanicInfo;
 use core::{
     ffi::{c_char, c_void},
-    panic::PanicInfo,
     ptr::addr_of,
 };
 
 use critical_section::RawRestoreState;
 
+// Disable unless we're buliding with our custom target explicitly, so rust-analyzer doesn't trip up
+// on conflicting panic handler implementations with std
+#[cfg(target_arch = "powerpc")]
 #[panic_handler]
 fn on_panic(panic_info: &PanicInfo) -> ! {
     match panic_info.location() {

--- a/crates/smb2_practice_mod/src/mods/ballcolor.rs
+++ b/crates/smb2_practice_mod/src/mods/ballcolor.rs
@@ -64,7 +64,6 @@ pub struct BallColor {
     rainbow: u32,
     default_color: mkb::GXColor,
     current_color: mkb::GXColor,
-    load_stagedef_hook: LoadStagedefHook,
 }
 
 impl Default for BallColor {
@@ -76,7 +75,6 @@ impl Default for BallColor {
             rainbow: 0,
             default_color: unsafe { *(0x80472a34 as *const mkb::GXColor) },
             current_color: Default::default(),
-            load_stagedef_hook: Default::default(),
         }
     }
 }

--- a/crates/smb2_practice_mod/src/mods/ballcolor.rs
+++ b/crates/smb2_practice_mod/src/mods/ballcolor.rs
@@ -2,10 +2,9 @@ use critical_section::Mutex;
 use num_enum::TryFromPrimitive;
 
 use mkb::mkb;
-use once_cell::sync::Lazy;
 
 use crate::{
-    app::{with_app, AppContext},
+    app::with_app,
     hook,
     systems::{
         draw,

--- a/crates/smb2_practice_mod/src/mods/ballcolor.rs
+++ b/crates/smb2_practice_mod/src/mods/ballcolor.rs
@@ -1,22 +1,37 @@
+use critical_section::Mutex;
 use num_enum::TryFromPrimitive;
 
 use mkb::mkb;
+use once_cell::sync::Lazy;
 
 use crate::{
-    app::AppContext,
+    app::{with_app, AppContext},
     hook,
     systems::{
         draw,
         pref::{Pref, U8Pref},
     },
+    utils::misc::with_mutex,
 };
+
+struct Globals {
+    load_stagedef_hook: LoadStagedefHook,
+}
+
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    load_stagedef_hook: LoadStagedefHook::new(),
+});
 
 pub const COLOR_MIN: u8 = 0;
 pub const COLOR_MAX: u8 = 0xff;
 
-hook!(LoadStagedefHook, stage_id: u32 => (), mkb::load_stagedef, |stage_id, cx| {
-    cx.ball_color.borrow().load_stagedef_hook.call(stage_id);
-    cx.ball_color.borrow_mut().switch_monkey(&mut cx.pref.borrow_mut());
+hook!(LoadStagedefHook, stage_id: u32 => (), mkb::load_stagedef, |stage_id| {
+    with_mutex(&GLOBALS, |cx| {
+        cx.load_stagedef_hook.call(stage_id);
+    });
+    with_app(|cx| {
+        cx.ball_color.switch_monkey(&mut cx.pref);
+    });
 });
 
 #[derive(PartialEq, Eq, TryFromPrimitive)]
@@ -55,20 +70,19 @@ pub struct BallColor {
 
 impl Default for BallColor {
     fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.load_stagedef_hook.hook();
+        });
         Self {
             rainbow: 0,
             default_color: unsafe { *(0x80472a34 as *const mkb::GXColor) },
-            current_color: mkb::GXColor::default(),
-            load_stagedef_hook: LoadStagedefHook::default(),
+            current_color: Default::default(),
+            load_stagedef_hook: Default::default(),
         }
     }
 }
 
 impl BallColor {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.load_stagedef_hook.hook();
-    }
-
     pub fn get_current_color(&self) -> mkb::GXColor {
         self.current_color
     }
@@ -112,9 +126,8 @@ impl BallColor {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
+    pub fn tick(&mut self, pref: &Pref) {
         unsafe {
-            let pref = &mut cx.pref.borrow_mut();
             let ball_type = BallColorType::try_from(pref.get_u8(U8Pref::BallColorType)).unwrap();
 
             if mkb::main_mode != mkb::MD_GAME

--- a/crates/smb2_practice_mod/src/mods/banans.rs
+++ b/crates/smb2_practice_mod/src/mods/banans.rs
@@ -1,5 +1,4 @@
 use crate::{
-    app::AppContext,
     systems::pref::{BoolPref, Pref},
     utils::patch,
 };

--- a/crates/smb2_practice_mod/src/mods/banans.rs
+++ b/crates/smb2_practice_mod/src/mods/banans.rs
@@ -1,11 +1,14 @@
-use crate::{app::AppContext, systems::pref::BoolPref, utils::patch};
+use crate::{
+    app::AppContext,
+    systems::pref::{BoolPref, Pref},
+    utils::patch,
+};
 
 #[derive(Default)]
 pub struct Banans {}
 
 impl Banans {
-    pub fn tick(&self, cx: &AppContext) {
-        let pref = &mut cx.pref.borrow_mut();
+    pub fn tick(&self, pref: &Pref) {
         if pref.did_change_bool(BoolPref::BananaCounter9999) {
             if pref.get_bool(BoolPref::BananaCounter9999) {
                 unsafe {

--- a/crates/smb2_practice_mod/src/mods/camera.rs
+++ b/crates/smb2_practice_mod/src/mods/camera.rs
@@ -1,7 +1,6 @@
 use mkb::mkb;
 use num_enum::TryFromPrimitive;
 
-use crate::app::AppContext;
 use crate::patch;
 use crate::systems::pref::Pref;
 use crate::systems::pref::{self, U8Pref};

--- a/crates/smb2_practice_mod/src/mods/camera.rs
+++ b/crates/smb2_practice_mod/src/mods/camera.rs
@@ -7,10 +7,6 @@ use crate::systems::pref::Pref;
 use crate::systems::pref::{self, U8Pref};
 use crate::utils::ppc;
 
-struct Context<'a> {
-    pref: &'a mut Pref,
-}
-
 #[derive(TryFromPrimitive)]
 #[repr(u8)]
 enum CameraType {
@@ -23,12 +19,12 @@ enum CameraType {
 pub struct Camera {}
 
 impl Camera {
-    unsafe fn tick_unsafe(&self, cx: &mut Context) {
-        let value = cx.pref.get_u8(U8Pref::Camera).try_into().unwrap();
+    unsafe fn tick_unsafe(&self, pref: &Pref) {
+        let value = pref.get_u8(U8Pref::Camera).try_into().unwrap();
 
         match value {
             CameraType::Default => {
-                if cx.pref.did_change_u8(pref::U8Pref::Camera) {
+                if pref.did_change_u8(pref::U8Pref::Camera) {
                     // restore cam to smb2 once (so toggle still works)
                     if mkb::cameras[0].mode == 0x1 {
                         mkb::cameras[0].mode = 0x4c;
@@ -69,12 +65,9 @@ impl Camera {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let cx = &mut Context {
-            pref: &mut cx.pref.borrow_mut(),
-        };
+    pub fn tick(&mut self, pref: &Pref) {
         unsafe {
-            self.tick_unsafe(cx);
+            self.tick_unsafe(pref);
         }
     }
 }

--- a/crates/smb2_practice_mod/src/mods/cmseg.rs
+++ b/crates/smb2_practice_mod/src/mods/cmseg.rs
@@ -5,7 +5,7 @@ use mkb::mkb;
 use num_enum::TryFromPrimitive;
 
 use crate::{
-    app::{with_app, AppContext},
+    app::with_app,
     hook,
     systems::{
         draw,

--- a/crates/smb2_practice_mod/src/mods/cmseg.rs
+++ b/crates/smb2_practice_mod/src/mods/cmseg.rs
@@ -1,21 +1,36 @@
 use core::{ffi::c_long, ptr::null_mut};
 
+use critical_section::Mutex;
 use mkb::mkb;
 use num_enum::TryFromPrimitive;
 
 use crate::{
-    app::AppContext,
+    app::{with_app, AppContext},
     hook,
     systems::{
         draw,
         pref::{BoolPref, Pref, U8Pref},
     },
-    utils::timerdisp,
+    utils::{misc::with_mutex, timerdisp},
 };
 
-hook!(ResetCmCourseHook => (), mkb::g_reset_cm_course, |cx| {
-    cx.cm_seg.borrow().reset_cm_course_hook.call();
-    cx.cm_seg.borrow_mut().on_reset_cm_course();
+use super::freecam::Freecam;
+
+struct Globals {
+    reset_cm_course_hook: ResetCmCourseHook,
+}
+
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    reset_cm_course_hook: ResetCmCourseHook::new(),
+});
+
+hook!(ResetCmCourseHook => (), mkb::g_reset_cm_course, || {
+    with_mutex(&GLOBALS, |cx| {
+        cx.reset_cm_course_hook.call();
+    });
+    with_app(|cx| {
+        cx.cm_seg.on_reset_cm_course();
+    });
 });
 
 #[derive(Copy, Clone, PartialEq, Default)]
@@ -58,7 +73,6 @@ enum Chara {
 }
 
 pub struct CmSeg {
-    reset_cm_course_hook: ResetCmCourseHook,
     state: State,
     seg_request: Seg,
     start_time: u32,
@@ -72,8 +86,10 @@ pub struct CmSeg {
 
 impl Default for CmSeg {
     fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.reset_cm_course_hook.hook();
+        });
         Self {
-            reset_cm_course_hook: Default::default(),
             state: Default::default(),
             seg_request: Default::default(),
             start_time: 0,
@@ -95,10 +111,6 @@ const APE_CHARAS: [mkb::ApeCharacter; 4] = [
 ];
 
 impl CmSeg {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.reset_cm_course_hook.hook();
-    }
-
     fn gen_course(&mut self, course_idx: usize, start_course_stage_num: u16, stage_count: u16) {
         let mut start_entry_idx = None;
         let mut end_entry_idx = None;
@@ -371,9 +383,8 @@ impl CmSeg {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
+    pub fn tick(&mut self, pref: &Pref) {
         unsafe {
-            let pref = &cx.pref.borrow();
             match self.state {
                 State::LoadMenu => self.state_load_menu(),
                 State::EnterCm => self.state_enter_cm(),
@@ -384,9 +395,7 @@ impl CmSeg {
         }
     }
 
-    pub fn draw(&self, cx: &AppContext) {
-        let pref = &mut cx.pref.borrow_mut();
-        let freecam = &mut cx.freecam.borrow_mut();
+    pub fn draw(&self, pref: &Pref, freecam: &Freecam) {
         if !pref.get_bool(BoolPref::CmTimer) || freecam.should_hide_hud(pref) {
             return;
         }

--- a/crates/smb2_practice_mod/src/mods/dpad.rs
+++ b/crates/smb2_practice_mod/src/mods/dpad.rs
@@ -1,36 +1,52 @@
 use crate::{
-    app::AppContext,
+    app::{with_app, AppContext},
     hook,
     systems::pref::{BoolPref, Pref},
+    utils::misc::with_mutex,
 };
+use critical_section::Mutex;
 use mkb::mkb;
 
-hook!(PadReadHook, statuses: *mut mkb::PADStatus => u32, mkb::PADRead, |statuses, cx| {
-    let dpad = &mut cx.dpad.borrow_mut();
-    let pref = &mut cx.pref.borrow_mut();
-
-    let ret = dpad.pad_read_hook.call(statuses);
-    dpad.on_pad_read(statuses, pref);
+hook!(PadReadHook, statuses: *mut mkb::PADStatus => u32, mkb::PADRead, |statuses| {
+    let ret = with_mutex(&GLOBALS, |cx| {
+        cx.pad_read_hook.call(statuses)
+    });
+    with_app(|cx| {
+        cx.dpad.on_pad_read(statuses, &cx.pref);
+    });
     ret
 });
 
-hook!(CreateSpeedSpritesHook, x: f32, y: f32 => (), mkb::create_speed_sprites, |x, y, cx| {
-    cx.dpad.borrow().create_speed_sprites_hook.call(x + 5.0, y);
+hook!(CreateSpeedSpritesHook, x: f32, y: f32 => (), mkb::create_speed_sprites, |x, y| {
+    with_mutex(&GLOBALS, |cx| {
+        cx.create_speed_sprites_hook.call(x + 5.0, y);
+    });
 });
 
-#[derive(Default)]
-pub struct Dpad {
+struct Globals {
     pad_read_hook: PadReadHook,
     create_speed_sprites_hook: CreateSpeedSpritesHook,
 }
 
-impl Dpad {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.pad_read_hook.hook();
-        self.create_speed_sprites_hook.hook();
-    }
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    pad_read_hook: PadReadHook::new(),
+    create_speed_sprites_hook: CreateSpeedSpritesHook::new(),
+});
 
-    pub fn on_pad_read(&self, statuses: *mut mkb::PADStatus, pref: &mut Pref) {
+pub struct Dpad {}
+
+impl Default for Dpad {
+    fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.pad_read_hook.hook();
+            cx.create_speed_sprites_hook.hook();
+        });
+        Self {}
+    }
+}
+
+impl Dpad {
+    pub fn on_pad_read(&self, statuses: *mut mkb::PADStatus, pref: &Pref) {
         unsafe {
             if !pref.get_bool(BoolPref::DpadControls) {
                 return;

--- a/crates/smb2_practice_mod/src/mods/dpad.rs
+++ b/crates/smb2_practice_mod/src/mods/dpad.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::{with_app, AppContext},
+    app::with_app,
     hook,
     systems::pref::{BoolPref, Pref},
     utils::misc::with_mutex,

--- a/crates/smb2_practice_mod/src/mods/fallout.rs
+++ b/crates/smb2_practice_mod/src/mods/fallout.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::{with_app, AppContext},
+    app::with_app,
     hook,
     utils::misc::with_mutex,
 };
@@ -8,7 +8,6 @@ use core::ffi::c_int;
 use critical_section::Mutex;
 use mkb::mkb;
 use num_enum::TryFromPrimitive;
-use once_cell::sync::Lazy;
 
 use crate::{
     systems::pref::{BoolPref, Pref, U8Pref},

--- a/crates/smb2_practice_mod/src/mods/freecam.rs
+++ b/crates/smb2_practice_mod/src/mods/freecam.rs
@@ -1,10 +1,9 @@
-use core::cell::RefCell;
 
 use critical_section::Mutex;
 use mkb::mkb;
 use once_cell::sync::Lazy;
 
-use crate::app::{self, with_app, AppContext};
+use crate::app::{with_app};
 use crate::systems::binds::Binds;
 use crate::systems::draw::{self, Draw, NotifyDuration};
 use crate::systems::pad::{self, Pad, Prio};

--- a/crates/smb2_practice_mod/src/mods/freecam.rs
+++ b/crates/smb2_practice_mod/src/mods/freecam.rs
@@ -1,9 +1,8 @@
-
 use critical_section::Mutex;
 use mkb::mkb;
 use once_cell::sync::Lazy;
 
-use crate::app::{with_app};
+use crate::app::with_app;
 use crate::systems::binds::Binds;
 use crate::systems::draw::{self, Draw, NotifyDuration};
 use crate::systems::pad::{self, Pad, Prio};

--- a/crates/smb2_practice_mod/src/mods/gotostory.rs
+++ b/crates/smb2_practice_mod/src/mods/gotostory.rs
@@ -38,7 +38,7 @@ impl GoToStory {
         }
     }
 
-    pub fn tick(&mut self, _cx: &AppContext) {
+    pub fn tick(&mut self) {
         unsafe {
             match self.state {
                 State::LoadMenuReq => {

--- a/crates/smb2_practice_mod/src/mods/gotostory.rs
+++ b/crates/smb2_practice_mod/src/mods/gotostory.rs
@@ -1,4 +1,3 @@
-use crate::app::AppContext;
 use mkb::mkb;
 
 #[derive(Default)]

--- a/crates/smb2_practice_mod/src/mods/hide.rs
+++ b/crates/smb2_practice_mod/src/mods/hide.rs
@@ -3,7 +3,7 @@ use mkb::mkb;
 use once_cell::sync::Lazy;
 
 use crate::{
-    app::{with_app},
+    app::with_app,
     hook,
     systems::pref::{BoolPref, Pref},
     utils::{misc::with_mutex, patch},

--- a/crates/smb2_practice_mod/src/mods/hide.rs
+++ b/crates/smb2_practice_mod/src/mods/hide.rs
@@ -1,6 +1,5 @@
 use critical_section::Mutex;
 use mkb::mkb;
-use once_cell::sync::Lazy;
 
 use crate::{
     app::with_app,
@@ -10,7 +9,6 @@ use crate::{
 };
 
 // BG
-#[derive(Default)]
 struct Globals {
     draw_bg_hook: DrawBgHook,
     clear_hook: ClearHook,
@@ -23,7 +21,17 @@ struct Globals {
     draw_effects_hook: DrawEffectsHook,
 }
 
-static GLOBALS: Lazy<Mutex<Globals>> = Lazy::new(|| Mutex::new(Globals::default()));
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    draw_bg_hook: DrawBgHook::new(),
+    clear_hook: ClearHook::new(),
+    draw_sprite_hook: DrawSpriteHook::new(),
+    draw_minimap_hook: DrawMinimapHook::new(),
+    draw_stage_hook: DrawStageHook::new(),
+    draw_ball_hook: DrawBallHook::new(),
+    draw_items_hook: DrawItemsHook::new(),
+    draw_stobjs_hook: DrawStobjsHook::new(),
+    draw_effects_hook: DrawEffectsHook::new(),
+});
 
 hook!(DrawBgHook => (), mkb::g_draw_bg, || {
     let should_hide = with_app(|cx| {

--- a/crates/smb2_practice_mod/src/mods/hide.rs
+++ b/crates/smb2_practice_mod/src/mods/hide.rs
@@ -3,7 +3,7 @@ use mkb::mkb;
 use once_cell::sync::Lazy;
 
 use crate::{
-    app::{self, with_app, AppContext},
+    app::{with_app},
     hook,
     systems::pref::{BoolPref, Pref},
     utils::{misc::with_mutex, patch},

--- a/crates/smb2_practice_mod/src/mods/hide.rs
+++ b/crates/smb2_practice_mod/src/mods/hide.rs
@@ -1,121 +1,168 @@
+use critical_section::Mutex;
 use mkb::mkb;
+use once_cell::sync::Lazy;
 
 use crate::{
-    app::{self, AppContext},
+    app::{self, with_app, AppContext},
     hook,
     systems::pref::{BoolPref, Pref},
-    utils::patch,
+    utils::{misc::with_mutex, patch},
 };
 
 // BG
-hook!(DrawBgHook => (), mkb::g_draw_bg, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    if !should_hide_bg(pref) {
-        hide.draw_bg_hook.call();
-    }
+#[derive(Default)]
+struct Globals {
+    draw_bg_hook: DrawBgHook,
+    clear_hook: ClearHook,
+    draw_sprite_hook: DrawSpriteHook,
+    draw_minimap_hook: DrawMinimapHook,
+    draw_stage_hook: DrawStageHook,
+    draw_ball_hook: DrawBallHook,
+    draw_items_hook: DrawItemsHook,
+    draw_stobjs_hook: DrawStobjsHook,
+    draw_effects_hook: DrawEffectsHook,
+}
+
+static GLOBALS: Lazy<Mutex<Globals>> = Lazy::new(|| Mutex::new(Globals::default()));
+
+hook!(DrawBgHook => (), mkb::g_draw_bg, || {
+    let should_hide = with_app(|cx| {
+        should_hide_bg(&cx.pref)
+    });
+
+    with_mutex(&GLOBALS, |cx| {
+        if !should_hide {
+            cx.draw_bg_hook.call();
+        }
+    });
 });
 
-hook!(ClearHook => (), mkb::g_set_clear_color, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    if should_hide_bg(pref) {
-        unsafe {
-            let backup_color = mkb::g_some_theme_color;
-            let backup_override_r = mkb::g_override_clear_r;
-            let backup_override_g = mkb::g_override_clear_g;
-            let backup_override_b = mkb::g_override_clear_b;
+hook!(ClearHook => (), mkb::g_set_clear_color, || {
+    let should_hide = with_app(|cx| {
+        should_hide_bg(&cx.pref)
+    });
 
-            mkb::g_some_theme_color = mkb::GXColor {r: 0, g: 0, b: 0, a: 0xff};
-            mkb::g_override_clear_r = 0;
-            mkb::g_override_clear_g = 0;
-            mkb::g_override_clear_b = 0;
+    with_mutex(&GLOBALS, |cx| {
+        if should_hide {
+            unsafe {
+                let backup_color = mkb::g_some_theme_color;
+                let backup_override_r = mkb::g_override_clear_r;
+                let backup_override_g = mkb::g_override_clear_g;
+                let backup_override_b = mkb::g_override_clear_b;
 
-            hide.clear_hook.call();
+                mkb::g_some_theme_color = mkb::GXColor {r: 0, g: 0, b: 0, a: 0xff};
+                mkb::g_override_clear_r = 0;
+                mkb::g_override_clear_g = 0;
+                mkb::g_override_clear_b = 0;
 
-            mkb::g_some_theme_color = backup_color;
-            mkb::g_override_clear_r = backup_override_r;
-            mkb::g_override_clear_g = backup_override_g;
-            mkb::g_override_clear_b = backup_override_b;
+                cx.clear_hook.call();
+
+                mkb::g_some_theme_color = backup_color;
+                mkb::g_override_clear_r = backup_override_r;
+                mkb::g_override_clear_g = backup_override_g;
+                mkb::g_override_clear_b = backup_override_b;
+            }
+        } else {
+            cx.clear_hook.call();
         }
-    } else {
-        hide.clear_hook.call();
-    }
+    });
 });
 
 // HUD
-hook!(DrawSpriteHook, sprite: *mut mkb::Sprite => (), mkb::draw_sprite, |sprite, cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    let freecam = &mut cx.freecam.borrow_mut();
-    unsafe {
-        // Hide every sprite except the pause menu
-        let hide_hud = pref.get_bool(BoolPref::HideHud);
-        let freecam_hide = freecam.should_hide_hud(pref);
-        let correct_mode = mkb::main_mode == mkb::MD_GAME;
-        let disp_func = (*sprite).disp_func;
-        let is_pausemenu_sprite = disp_func == Some(mkb::sprite_pausemenu_disp);
-        if !((hide_hud || freecam_hide) && correct_mode && !is_pausemenu_sprite) {
-            hide.draw_sprite_hook.call(sprite);
+hook!(DrawSpriteHook, sprite: *mut mkb::Sprite => (), mkb::draw_sprite, |sprite| {
+    let (hide_hud, freecam_hide) = with_app(|cx| {
+        (cx.pref.get_bool(BoolPref::HideHud), cx.freecam.should_hide_hud(&cx.pref))
+    });
+
+    with_mutex(&GLOBALS, |cx| {
+        unsafe {
+            let correct_mode = mkb::main_mode == mkb::MD_GAME;
+            let disp_func = (*sprite).disp_func;
+            let is_pausemenu_sprite = disp_func == Some(mkb::sprite_pausemenu_disp);
+            if !((hide_hud || freecam_hide) && correct_mode && !is_pausemenu_sprite) {
+                cx.draw_sprite_hook.call(sprite);
+            }
         }
-    }
+    });
 });
 
-hook!(DrawMinimapHook => (), mkb::g_draw_minimap, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    let freecam = &mut cx.freecam.borrow_mut();
+hook!(DrawMinimapHook => (), mkb::g_draw_minimap, || {
+    let (hide_hud, freecam_hide) = with_app(|cx| {
+        let pref = &cx.pref;
+        let freecam = &cx.freecam;
+        (pref.get_bool(BoolPref::HideHud), freecam.should_hide_hud(pref))
+    });
 
-    let hide_hud = pref.get_bool(BoolPref::HideHud);
-    let freecam_hide = freecam.should_hide_hud(pref);
-    if !(hide_hud || freecam_hide) {
-        hide.draw_minimap_hook.call();
-    }
+    with_mutex(&GLOBALS, |cx| {
+        if !(hide_hud || freecam_hide) {
+            cx.draw_minimap_hook.call();
+        }
+    });
 });
 
 // Stage
-hook!(DrawStageHook => (), mkb::g_draw_stage, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    if !pref.get_bool(BoolPref::HideStage) {
-        hide.draw_stage_hook.call();
-    }
+hook!(DrawStageHook => (), mkb::g_draw_stage, || {
+    let should_hide = with_app(|cx| {
+        cx.pref.get_bool(BoolPref::HideStage)
+    });
+
+    with_mutex(&GLOBALS, |cx| {
+        if !should_hide {
+            cx.draw_stage_hook.call();
+        }
+    });
 });
 
 // Ball
-hook!(DrawBallHook => (), mkb::g_draw_ball_and_ape, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    if !pref.get_bool(BoolPref::HideBall) {
-        hide.draw_ball_hook.call();
-    }
+hook!(DrawBallHook => (), mkb::g_draw_ball_and_ape, || {
+    let should_hide = with_app(|cx| {
+        cx.pref.get_bool(BoolPref::HideBall)
+    });
+
+    with_mutex(&GLOBALS, |cx| {
+        if !should_hide {
+            cx.draw_ball_hook.call();
+        }
+    });
 });
 
 // Items
-hook!(DrawItemsHook => (), mkb::draw_items, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    if !pref.get_bool(BoolPref::HideItems) {
-        hide.draw_items_hook.call();
-    }
+hook!(DrawItemsHook => (), mkb::draw_items, || {
+    let should_hide = with_app(|cx| {
+        cx.pref.get_bool(BoolPref::HideItems)
+    });
+
+    with_mutex(&GLOBALS, |cx| {
+        if !should_hide {
+            cx.draw_items_hook.call();
+        }
+    });
 });
 
 // Stage objects
-hook!(DrawStobjsHook => (), mkb::g_draw_stobjs, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    if !pref.get_bool(BoolPref::HideStobjs) {
-        hide.draw_stobjs_hook.call();
-    }
+hook!(DrawStobjsHook => (), mkb::g_draw_stobjs, || {
+    let should_hide = with_app(|cx| {
+        cx.pref.get_bool(BoolPref::HideStobjs)
+    });
+
+    with_mutex(&GLOBALS, |cx| {
+        if !should_hide {
+            cx.draw_stobjs_hook.call();
+        }
+    });
 });
 
 // Effects
-hook!(DrawEffectsHook => (), mkb::g_draw_effects, |cx| {
-    let hide = &cx.hide.borrow();
-    let pref = &cx.pref.borrow();
-    if !pref.get_bool(BoolPref::HideEffects) {
-        hide.draw_effects_hook.call();
-    }
+hook!(DrawEffectsHook => (), mkb::g_draw_effects, || {
+    let should_hide = with_app(|cx| {
+        cx.pref.get_bool(BoolPref::HideEffects)
+    });
+
+    with_mutex(&GLOBALS, |cx| {
+        if !should_hide {
+            cx.draw_effects_hook.call();
+        }
+    });
 });
 
 fn should_hide_bg(pref: &Pref) -> bool {
@@ -124,54 +171,44 @@ fn should_hide_bg(pref: &Pref) -> bool {
 
 // At some point we should make a `hook_call!` macro for bl hooks that works like `hook!`
 unsafe extern "C" fn avdisp_set_fog_color_hook(r: u8, g: u8, b: u8) {
-    critical_section::with(|cs| {
-        let cx = app::APP_CONTEXT.borrow(cs);
-        if should_hide_bg(&cx.pref.borrow()) {
-            mkb::avdisp_set_fog_color(0, 0, 0);
-        } else {
-            mkb::avdisp_set_fog_color(r, g, b);
-        }
-    });
+    let should_hide = with_app(|cx| should_hide_bg(&cx.pref));
+
+    if should_hide {
+        mkb::avdisp_set_fog_color(0, 0, 0);
+    } else {
+        mkb::avdisp_set_fog_color(r, g, b);
+    }
 }
 
 unsafe extern "C" fn nl2ngc_set_fog_color_hook(r: u8, g: u8, b: u8) {
-    critical_section::with(|cs| {
-        let cx = app::APP_CONTEXT.borrow(cs);
-        if should_hide_bg(&cx.pref.borrow()) {
-            mkb::nl2ngc_set_fog_color(0, 0, 0);
-        } else {
-            mkb::nl2ngc_set_fog_color(r, g, b);
-        }
-    });
+    let should_hide = with_app(|cx| should_hide_bg(&cx.pref));
+
+    if should_hide {
+        mkb::nl2ngc_set_fog_color(0, 0, 0);
+    } else {
+        mkb::nl2ngc_set_fog_color(r, g, b);
+    }
 }
 
-#[derive(Default)]
-pub struct Hide {
-    pub draw_bg_hook: DrawBgHook,
-    pub clear_hook: ClearHook,
-    pub draw_sprite_hook: DrawSpriteHook,
-    pub draw_minimap_hook: DrawMinimapHook,
-    pub draw_stage_hook: DrawStageHook,
-    pub draw_ball_hook: DrawBallHook,
-    pub draw_items_hook: DrawItemsHook,
-    pub draw_stobjs_hook: DrawStobjsHook,
-    pub draw_effects_hook: DrawEffectsHook,
-}
+pub struct Hide {}
 
-impl Hide {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        unsafe {
-            patch::write_branch_bl(0x80352e58 as *mut _, avdisp_set_fog_color_hook as *mut _);
-            patch::write_branch_bl(0x80352eac as *mut _, nl2ngc_set_fog_color_hook as *mut _);
-        }
-        self.draw_bg_hook.hook();
-        self.clear_hook.hook();
-        self.draw_sprite_hook.hook();
-        self.draw_minimap_hook.hook();
-        self.draw_stage_hook.hook();
-        self.draw_ball_hook.hook();
-        self.draw_items_hook.hook();
-        self.draw_stobjs_hook.hook();
-        self.draw_effects_hook.hook();
+impl Default for Hide {
+    fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            unsafe {
+                patch::write_branch_bl(0x80352e58 as *mut _, avdisp_set_fog_color_hook as *mut _);
+                patch::write_branch_bl(0x80352eac as *mut _, nl2ngc_set_fog_color_hook as *mut _);
+            }
+            cx.draw_bg_hook.hook();
+            cx.clear_hook.hook();
+            cx.draw_sprite_hook.hook();
+            cx.draw_minimap_hook.hook();
+            cx.draw_stage_hook.hook();
+            cx.draw_ball_hook.hook();
+            cx.draw_items_hook.hook();
+            cx.draw_stobjs_hook.hook();
+            cx.draw_effects_hook.hook();
+        });
+        Self {}
     }
 }

--- a/crates/smb2_practice_mod/src/mods/ilbattle.rs
+++ b/crates/smb2_practice_mod/src/mods/ilbattle.rs
@@ -16,10 +16,10 @@ use crate::{
 use super::{freecam::Freecam, validate::Validate};
 
 struct Context<'a> {
-    pref: &'a mut Pref,
-    freecam: &'a mut Freecam,
-    binds: &'a mut Binds,
-    pad: &'a mut Pad,
+    pref: &'a Pref,
+    freecam: &'a Freecam,
+    binds: &'a Binds,
+    pad: &'a Pad,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
@@ -135,7 +135,7 @@ impl IlBattle {
         }
     }
 
-    fn battle_display(&mut self, text_color: mkb::GXColor, cx: &mut Context) {
+    fn battle_display(&mut self, text_color: mkb::GXColor, cx: &Context) {
         let battle_hours = self.battle_frames / HOUR_FRAMES;
         let battle_minutes = self.battle_frames % HOUR_FRAMES / MINUTE_FRAMES;
         let battle_seconds = self.battle_frames % MINUTE_FRAMES / SECOND_FRAMES;
@@ -314,7 +314,7 @@ impl IlBattle {
         }
     }
 
-    fn clear_display(&mut self, cx: &mut Context) {
+    fn clear_display(&mut self, cx: &Context) {
         let battle_len = cx.pref.get_u8(U8Pref::IlBattleLength);
         let battle_len = IlBattleLength::try_from(battle_len).unwrap();
 
@@ -332,12 +332,12 @@ impl IlBattle {
         self.battle_length = Self::convert_battle_length(battle_len);
     }
 
-    fn new_battle(&mut self, cx: &mut Context) {
+    fn new_battle(&mut self, cx: &Context) {
         self.clear_display(cx);
         self.state = IlBattleState::WaitForFirstRetry;
     }
 
-    fn track_first_retry(&mut self, cx: &mut Context) {
+    fn track_first_retry(&mut self, cx: &Context) {
         unsafe {
             let paused_now = *(0x805BC474 as *const u32) & 8 != 0;
             if !paused_now && mkb::sub_mode == mkb::SMD_GAME_READY_INIT {
@@ -348,7 +348,7 @@ impl IlBattle {
         }
     }
 
-    fn run_battle_timer(&mut self, cx: &mut Context) {
+    fn run_battle_timer(&mut self, cx: &Context) {
         unsafe {
             if mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT && !self.accepted_retry {
                 // track attempt counts
@@ -470,12 +470,12 @@ impl IlBattle {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let cx = &mut Context {
-            pref: &mut cx.pref.borrow_mut(),
-            freecam: &mut cx.freecam.borrow_mut(),
-            binds: &mut cx.binds.borrow_mut(),
-            pad: &mut cx.pad.borrow_mut(),
+    pub fn tick(&mut self, pref: &Pref, freecam: &Freecam, binds: &Binds, pad: &Pad) {
+        let cx = &Context {
+            pref,
+            freecam,
+            binds,
+            pad,
         };
 
         unsafe {
@@ -546,12 +546,12 @@ impl IlBattle {
         }
     }
 
-    pub fn draw(&mut self, cx: &AppContext) {
-        let cx = &mut Context {
-            pref: &mut cx.pref.borrow_mut(),
-            freecam: &mut cx.freecam.borrow_mut(),
-            binds: &mut cx.binds.borrow_mut(),
-            pad: &mut cx.pad.borrow_mut(),
+    pub fn draw(&mut self, pref: &Pref, freecam: &Freecam, binds: &Binds, pad: &Pad) {
+        let cx = &Context {
+            pref,
+            freecam,
+            binds,
+            pad,
         };
 
         unsafe {

--- a/crates/smb2_practice_mod/src/mods/ilbattle.rs
+++ b/crates/smb2_practice_mod/src/mods/ilbattle.rs
@@ -3,7 +3,6 @@ use mkb::mkb;
 use num_enum::TryFromPrimitive;
 
 use crate::{
-    app::AppContext,
     cstr_buf, fmt,
     systems::{
         binds::Binds,

--- a/crates/smb2_practice_mod/src/mods/ilmark.rs
+++ b/crates/smb2_practice_mod/src/mods/ilmark.rs
@@ -4,7 +4,6 @@ use arrayvec::ArrayString;
 use mkb::mkb;
 
 use crate::{
-    app::AppContext,
     cstr_buf,
     systems::{
         draw,

--- a/crates/smb2_practice_mod/src/mods/ilmark.rs
+++ b/crates/smb2_practice_mod/src/mods/ilmark.rs
@@ -10,10 +10,10 @@ use crate::{
         draw,
         pref::{BoolPref, Pref},
     },
-    utils::version,
+    utils::{libsavestate::LibSaveState, version},
 };
 
-use super::validate::Validate;
+use super::{freecam::Freecam, validate::Validate};
 
 pub struct IlMark {
     valid_run: bool,
@@ -42,7 +42,7 @@ impl IlMark {
         self.valid_run = true;
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
+    pub fn tick(&mut self, lib_save_state: &LibSaveState) {
         unsafe {
             if mkb::sub_mode != mkb::SMD_GAME_PLAY_MAIN
                 && mkb::sub_mode != mkb::SMD_GAME_GOAL_INIT
@@ -55,7 +55,7 @@ impl IlMark {
                 self.valid_run = false;
             }
 
-            if cx.lib_save_state.borrow().state_loaded_this_frame {
+            if lib_save_state.loaded_this_frame() {
                 self.valid_run = false;
             }
         }
@@ -91,9 +91,7 @@ impl IlMark {
         }
     }
 
-    pub fn draw(&self, cx: &AppContext) {
-        let pref = &cx.pref.borrow();
-        let freecam = &cx.freecam.borrow();
+    pub fn draw(&self, pref: &Pref, freecam: &Freecam) {
         if !self.is_ilmark_enabled(pref) || freecam.should_hide_hud(pref) {
             return;
         }

--- a/crates/smb2_practice_mod/src/mods/inputdisp.rs
+++ b/crates/smb2_practice_mod/src/mods/inputdisp.rs
@@ -27,10 +27,10 @@ pub enum InputDispColorType {
 }
 
 struct Context<'a> {
-    pad: &'a mut Pad,
-    pref: &'a mut Pref,
-    freecam: &'a mut Freecam,
-    ball_color: &'a mut BallColor,
+    pad: &'a Pad,
+    pref: &'a Pref,
+    freecam: &'a Freecam,
+    ball_color: &'a BallColor,
 }
 
 #[derive(Default)]
@@ -151,8 +151,7 @@ impl InputDisplay {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let pref = &mut cx.pref.borrow_mut();
+    pub fn tick(&mut self, pref: &Pref) {
         self.rainbow = (self.rainbow + 3) % 1080;
         self.set_sprite_visible(
             !pref.get_bool(BoolPref::InputDisp)
@@ -220,7 +219,7 @@ impl InputDisplay {
         draw::BLACK,  // Black
     ];
 
-    fn get_color(&self, cx: &mut Context) -> mkb::GXColor {
+    fn get_color(&self, cx: &Context) -> mkb::GXColor {
         let color_pref = cx.pref.get_u8(U8Pref::InputDispColorType);
         match InputDispColorType::try_from(color_pref).unwrap() {
             InputDispColorType::Default => {
@@ -241,13 +240,7 @@ impl InputDisplay {
         }
     }
 
-    fn draw_stick(
-        &self,
-        raw_stick_inputs: &StickState,
-        center: &Vec2d,
-        scale: f32,
-        cx: &mut Context,
-    ) {
+    fn draw_stick(&self, raw_stick_inputs: &StickState, center: &Vec2d, scale: f32, cx: &Context) {
         let chosen_color = self.get_color(cx);
 
         self.draw_ring(
@@ -293,7 +286,7 @@ impl InputDisplay {
         );
     }
 
-    fn draw_buttons(&self, center: &Vec2d, scale: f32, cx: &mut Context) {
+    fn draw_buttons(&self, center: &Vec2d, scale: f32, cx: &Context) {
         // We floor floats for now because no-std doesn't include a float rounding func
         if cx
             .pad
@@ -390,7 +383,7 @@ impl InputDisplay {
         stick_inputs: &StickState,
         center: &Vec2d,
         scale: f32,
-        cx: &mut Context,
+        cx: &Context,
     ) {
         if !cx.pref.get_bool(BoolPref::InputDispNotchIndicators) {
             return;
@@ -420,7 +413,7 @@ impl InputDisplay {
         &self,
         raw_stick_inputs: &StickState,
         stick_inputs: &StickState,
-        cx: &mut Context,
+        cx: &Context,
     ) {
         if !cx.pref.get_bool(BoolPref::InputDispRawStickInputs) {
             return;
@@ -461,12 +454,12 @@ impl InputDisplay {
         );
     }
 
-    pub fn draw(&mut self, cx: &AppContext) {
-        let cx = &mut Context {
-            pad: &mut cx.pad.borrow_mut(),
-            pref: &mut cx.pref.borrow_mut(),
-            freecam: &mut cx.freecam.borrow_mut(),
-            ball_color: &mut cx.ball_color.borrow_mut(),
+    pub fn draw(&mut self, pref: &Pref, pad: &Pad, freecam: &Freecam, ball_color: &BallColor) {
+        let cx = &Context {
+            pref,
+            pad,
+            freecam,
+            ball_color,
         };
 
         let in_replay = unsafe {

--- a/crates/smb2_practice_mod/src/mods/inputdisp.rs
+++ b/crates/smb2_practice_mod/src/mods/inputdisp.rs
@@ -6,14 +6,11 @@ use mkb::Vec2d;
 use num_enum::TryFromPrimitive;
 
 use crate::fmt;
-use crate::{
-    app::AppContext,
-    systems::{
+use crate::systems::{
         draw,
         pad::{self, Pad, Prio, StickState},
         pref::{BoolPref, Pref, U8Pref},
-    },
-};
+    };
 
 use super::{ballcolor::BallColor, freecam::Freecam};
 

--- a/crates/smb2_practice_mod/src/mods/jump.rs
+++ b/crates/smb2_practice_mod/src/mods/jump.rs
@@ -297,16 +297,13 @@ impl Jump {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let mut pref = cx.pref.borrow_mut();
-        let pad = cx.pad.borrow_mut();
-
+    pub fn tick(&mut self, pref: &mut Pref, pad: &Pad) {
         let enabled = pref.get_bool(BoolPref::JumpMod);
         if pref.did_change_bool(BoolPref::JumpMod) {
             if enabled {
-                self.enable(&mut pref);
+                self.enable(pref);
             } else {
-                self.disable(&mut pref);
+                self.disable(pref);
             }
         }
         if enabled {
@@ -319,10 +316,6 @@ impl Jump {
                 pref.save();
             }
 
-            // Jumping calls soundreqid which reads pref, so drop mutable borrow to pref
-            drop(pref);
-            let pref = cx.pref.borrow();
-
             // Don't run logic while paused
             let paused_now = unsafe { *(0x805BC474 as *const u32) & 8 };
             if paused_now != 0 {
@@ -333,9 +326,9 @@ impl Jump {
             let new_jump_profile = pref.get_u8(U8Pref::JumpProfile) == 0;
 
             if new_jump_profile {
-                self.jumping(&pref, &pad);
+                self.jumping(pref, pad);
             } else {
-                self.classic_jumping(&pad);
+                self.classic_jumping(pad);
             }
         }
     }

--- a/crates/smb2_practice_mod/src/mods/jump.rs
+++ b/crates/smb2_practice_mod/src/mods/jump.rs
@@ -3,7 +3,6 @@ use num_enum::TryFromPrimitive;
 use mkb::mkb;
 
 use crate::{
-    app::AppContext,
     systems::{
         pad::{Pad, Prio},
         pref::{BoolPref, Pref, U8Pref},

--- a/crates/smb2_practice_mod/src/mods/marathon.rs
+++ b/crates/smb2_practice_mod/src/mods/marathon.rs
@@ -1,9 +1,6 @@
 use mkb::mkb;
 
-use crate::{
-    app::AppContext,
-    systems::pref::{BoolPref, Pref},
-};
+use crate::systems::pref::{BoolPref, Pref};
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 enum MarathonState {

--- a/crates/smb2_practice_mod/src/mods/marathon.rs
+++ b/crates/smb2_practice_mod/src/mods/marathon.rs
@@ -1,6 +1,9 @@
 use mkb::mkb;
 
-use crate::{app::AppContext, systems::pref::BoolPref};
+use crate::{
+    app::AppContext,
+    systems::pref::{BoolPref, Pref},
+};
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 enum MarathonState {
@@ -111,8 +114,7 @@ impl Marathon {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let pref = &mut cx.pref.borrow_mut();
+    pub fn tick(&mut self, pref: &Pref) {
         if pref.get_bool(BoolPref::Marathon) {
             match self.state {
                 MarathonState::WaitForGoal => self.wait_for_goal(),

--- a/crates/smb2_practice_mod/src/mods/physics.rs
+++ b/crates/smb2_practice_mod/src/mods/physics.rs
@@ -2,13 +2,10 @@ use mkb::mkb;
 
 use num_enum::TryFromPrimitive;
 
-use crate::{
-    app::AppContext,
-    systems::{
+use crate::systems::{
         draw,
         pref::{BoolPref, Pref, U8Pref},
-    },
-};
+    };
 
 use super::freecam::Freecam;
 

--- a/crates/smb2_practice_mod/src/mods/physics.rs
+++ b/crates/smb2_practice_mod/src/mods/physics.rs
@@ -13,8 +13,8 @@ use crate::{
 use super::freecam::Freecam;
 
 struct Context<'a> {
-    pref: &'a mut Pref,
-    freecam: &'a mut Freecam,
+    pref: &'a Pref,
+    freecam: &'a Freecam,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, TryFromPrimitive)]
@@ -52,7 +52,7 @@ impl Physics {
         preset != PhysicsPreset::Default
     }
 
-    fn change_physics(&mut self, cx: &mut Context) {
+    fn change_physics(&mut self, cx: &Context) {
         unsafe {
             // restore physics momentarily
             mkb::ball_friction = self.orig_friction;
@@ -98,19 +98,13 @@ impl Physics {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let cx = &mut Context {
-            pref: &mut cx.pref.borrow_mut(),
-            freecam: &mut cx.freecam.borrow_mut(),
-        };
+    pub fn tick(&mut self, pref: &Pref, freecam: &Freecam) {
+        let cx = &Context { pref, freecam };
         self.change_physics(cx);
     }
 
-    pub fn draw(&self, cx: &AppContext) {
-        let cx = &mut Context {
-            pref: &mut cx.pref.borrow_mut(),
-            freecam: &mut cx.freecam.borrow_mut(),
-        };
+    pub fn draw(&self, pref: &Pref, freecam: &Freecam) {
+        let cx = &Context { pref, freecam };
         unsafe {
             if mkb::sub_mode != mkb::SMD_GAME_READY_INIT
                 && mkb::sub_mode != mkb::SMD_GAME_READY_MAIN

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -1,7 +1,10 @@
+use core::cell::Cell;
+
+use critical_section::Mutex;
 use mkb::mkb;
 
 use crate::{
-    app::AppContext,
+    app::{with_app, AppContext},
     fmt, hook,
     systems::{
         binds::Binds,
@@ -9,76 +12,104 @@ use crate::{
         pad::{Dir, Pad, Prio},
         pref::{BoolPref, Pref, U8Pref},
     },
-    utils::libsavestate::{LibSaveState, LoadError, SaveError, SaveState},
+    utils::{
+        libsavestate::{LibSaveState, LoadError, SaveError, SaveState},
+        misc::with_mutex,
+    },
 };
 
 use super::timer::Timer;
 
-hook!(SetMinimapModeHook, mode: mkb::MinimapMode => (), mkb::set_minimap_mode, |mode, cx| {
-    let pref = &mut cx.pref.borrow_mut();
-    unsafe {
-        if !savestates_enabled(pref)
-            || !(mkb::main_mode == mkb::MD_GAME
-            && mkb::main_game_mode == mkb::PRACTICE_MODE &&
-            mode == mkb::MINIMAP_SHRINK)
-        {
-            cx.save_states_ui.borrow().set_minimap_mode_hook.call(mode);
+struct Globals {
+    set_minimap_mode_hook: SetMinimapModeHook,
+    savestates_enabled: Cell<bool>,
+}
+
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    set_minimap_mode_hook: SetMinimapModeHook::new(),
+    savestates_enabled: Cell::new(false),
+});
+
+// Reentrant hook, cannot use app state
+hook!(SetMinimapModeHook, mode: mkb::MinimapMode => (), mkb::set_minimap_mode, |mode| {
+    with_mutex(&GLOBALS, |cx| {
+        let enabled = !cx.savestates_enabled.get()
+            || !(unsafe {mkb::main_mode} == mkb::MD_GAME
+            && unsafe {mkb::main_game_mode} == mkb::PRACTICE_MODE &&
+            mode == mkb::MINIMAP_SHRINK);
+        if enabled {
+            cx.set_minimap_mode_hook.call(mode);
         }
-    }
+    });
 });
 
 struct Context<'a> {
-    pad: &'a mut Pad,
+    pref: &'a Pref,
+    pad: &'a Pad,
     draw: &'a mut Draw,
-    binds: &'a mut Binds,
-    libsavestate: &'a mut LibSaveState,
+    binds: &'a Binds,
+    lib_save_state: &'a mut LibSaveState,
     timer: &'a mut Timer,
 }
 
-#[derive(Default)]
 pub struct SaveStatesUi {
-    set_minimap_mode_hook: SetMinimapModeHook,
     states: [SaveState; 8],
     active_state_slot: i32,
     created_state_last_frame: bool,
     frame_advance_mode: bool,
 }
 
-impl SaveStatesUi {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.set_minimap_mode_hook.hook();
+impl Default for SaveStatesUi {
+    fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.set_minimap_mode_hook.hook();
+        });
+        Self {
+            states: Default::default(),
+            active_state_slot: 0,
+            created_state_last_frame: false,
+            frame_advance_mode: false,
+        }
     }
+}
 
+impl SaveStatesUi {
     fn is_either_trigger_held(&self, pad: &Pad) -> bool {
         pad.analog_down(mkb::PAI_LTRIG as mkb::PadAnalogInput, Prio::Low)
             || pad.analog_down(mkb::PAI_RTRIG as mkb::PadAnalogInput, Prio::Low)
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        // We must tightly scope our Pref usage to avoid a double borrow. libsavestate calls
-        // mkb::set_minimap_mode(), we hook it, and it uses pref
-        let disable_overwrite;
-        let clear_bind;
-        {
-            let pref = &mut cx.pref.borrow_mut();
-            if !savestates_enabled(pref) {
-                return;
-            }
-            disable_overwrite = pref.get_bool(BoolPref::SavestateDisableOverwrite);
-            clear_bind = pref.get_u8(U8Pref::SavestateClearBind);
-        }
-
-        let cx = Context {
-            pad: &mut cx.pad.borrow_mut(),
-            draw: &mut cx.draw.borrow_mut(),
-            binds: &mut cx.binds.borrow_mut(),
-            libsavestate: &mut cx.lib_save_state.borrow_mut(),
-            timer: &mut cx.timer.borrow_mut(),
+    pub fn tick(
+        &mut self,
+        pref: &Pref,
+        pad: &Pad,
+        draw: &mut Draw,
+        binds: &Binds,
+        lib_save_state: &mut LibSaveState,
+        timer: &mut Timer,
+    ) {
+        let cx = &mut Context {
+            pref,
+            pad,
+            draw,
+            binds,
+            lib_save_state,
+            timer,
         };
+
+        with_mutex(&GLOBALS, |g| {
+            g.savestates_enabled.set(savestates_enabled(cx.pref));
+        });
+
+        if !savestates_enabled(cx.pref) {
+            return;
+        }
+        let disable_overwrite = pref.get_bool(BoolPref::SavestateDisableOverwrite);
+        let clear_bind = pref.get_u8(U8Pref::SavestateClearBind);
 
         // Must tick savestates every frame
         for state in &mut self.states {
-            state.tick(cx.libsavestate, cx.timer);
+            state.tick(cx.lib_save_state, cx.timer);
         }
 
         if !self.is_either_trigger_held(cx.pad) {
@@ -215,7 +246,7 @@ impl SaveStatesUi {
             || (self.is_either_trigger_held(cx.pad) && cstick_dir != Dir::None)
         {
             let state = &mut self.states[self.active_state_slot as usize];
-            match state.load(cx.libsavestate, cx.timer) {
+            match state.load(cx.lib_save_state, cx.timer) {
                 Ok(()) => {}
                 Err(LoadError::MainMode) => {
                     // Unreachable

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -4,7 +4,6 @@ use critical_section::Mutex;
 use mkb::mkb;
 
 use crate::{
-    app::{with_app, AppContext},
     fmt, hook,
     systems::{
         binds::Binds,

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -29,7 +29,7 @@ static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
     savestates_enabled: Cell::new(false),
 });
 
-// Reentrant hook, cannot use app state
+// Re-entrant hook, cannot use app state
 hook!(SetMinimapModeHook, mode: mkb::MinimapMode => (), mkb::set_minimap_mode, |mode| {
     with_mutex(&GLOBALS, |cx| {
         let enabled = !cx.savestates_enabled.get()

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -12,7 +12,7 @@ use crate::{
         pref::{BoolPref, Pref, U8Pref},
     },
     utils::{
-        libsavestate::{LibSaveState, LoadError, SaveError, SaveState},
+        libsavestate::{LoadError, SaveError, SaveState},
         misc::with_mutex,
     },
 };
@@ -47,7 +47,6 @@ struct Context<'a> {
     pad: &'a Pad,
     draw: &'a mut Draw,
     binds: &'a Binds,
-    lib_save_state: &'a mut LibSaveState,
     timer: &'a mut Timer,
 }
 
@@ -84,7 +83,6 @@ impl SaveStatesUi {
         pad: &Pad,
         draw: &mut Draw,
         binds: &Binds,
-        lib_save_state: &mut LibSaveState,
         timer: &mut Timer,
     ) {
         let cx = &mut Context {
@@ -92,7 +90,6 @@ impl SaveStatesUi {
             pad,
             draw,
             binds,
-            lib_save_state,
             timer,
         };
 
@@ -108,7 +105,7 @@ impl SaveStatesUi {
 
         // Must tick savestates every frame
         for state in &mut self.states {
-            state.tick(cx.lib_save_state, cx.timer);
+            state.tick(cx.timer);
         }
 
         if !self.is_either_trigger_held(cx.pad) {
@@ -245,7 +242,7 @@ impl SaveStatesUi {
             || (self.is_either_trigger_held(cx.pad) && cstick_dir != Dir::None)
         {
             let state = &mut self.states[self.active_state_slot as usize];
-            match state.load(cx.lib_save_state, cx.timer) {
+            match state.load(cx.timer) {
                 Ok(()) => {}
                 Err(LoadError::MainMode) => {
                     // Unreachable

--- a/crates/smb2_practice_mod/src/mods/scratch.rs
+++ b/crates/smb2_practice_mod/src/mods/scratch.rs
@@ -1,4 +1,3 @@
-use crate::app::AppContext;
 
 #[derive(Default)]
 pub struct Scratch {}

--- a/crates/smb2_practice_mod/src/mods/scratch.rs
+++ b/crates/smb2_practice_mod/src/mods/scratch.rs
@@ -4,7 +4,7 @@ use crate::app::AppContext;
 pub struct Scratch {}
 
 impl Scratch {
-    pub fn tick(&self, _cx: &AppContext) {}
+    pub fn tick(&self) {}
 
-    pub fn draw(&self, _cx: &AppContext) {}
+    pub fn draw(&self) {}
 }

--- a/crates/smb2_practice_mod/src/mods/sfx.rs
+++ b/crates/smb2_practice_mod/src/mods/sfx.rs
@@ -99,7 +99,6 @@ impl Default for Sfx {
 }
 
 impl Sfx {
-    // TODO call this from app.rs
     pub fn tick(&mut self, pref: &Pref) {
         with_mutex(&GLOBALS, |cx| {
             if !self.initialized {

--- a/crates/smb2_practice_mod/src/mods/sfx.rs
+++ b/crates/smb2_practice_mod/src/mods/sfx.rs
@@ -16,7 +16,7 @@ hook!(SoftStreamStartHook, looping_state: u32, g_bgm_id: mkb::BgmTrack, param_3:
     }
 );
 
-// This hook is reentrant (called from jump mod) so cannot use app state
+// Re-entrant hook, cannot use app state
 hook!(SoundReqIdHook, sfx_idx: u32 => (), mkb::call_SoundReqID_arg_0, |sfx_idx| {
     with_mutex(&GLOBALS, |cx| {
         if !(cx.mute_timer_ding.get() && sfx_idx == 0x0003d806) {

--- a/crates/smb2_practice_mod/src/mods/stage_edits.rs
+++ b/crates/smb2_practice_mod/src/mods/stage_edits.rs
@@ -1,11 +1,22 @@
+use critical_section::Mutex;
 use mkb::mkb;
 
 use num_enum::TryFromPrimitive;
 
-use crate::{app::AppContext, hook, systems::pref::U8Pref};
+use crate::{
+    app::{with_app, AppContext},
+    hook,
+    systems::pref::{Pref, U8Pref},
+    utils::misc::with_mutex,
+};
 
-hook!(LoadStagedefHook, stage_id: u32 => (), mkb::load_stagedef, |stage_id, cx| {
-    cx.stage_edits.borrow_mut().on_load_stagedef(stage_id, cx);
+hook!(LoadStagedefHook, stage_id: u32 => (), mkb::load_stagedef, |stage_id| {
+    with_mutex(&GLOBALS, |cx| {
+        cx.load_stagedef_hook.call(stage_id);
+    });
+    with_app(|cx| {
+        cx.stage_edits.on_load_stagedef(&cx.pref);
+    });
 });
 
 #[derive(Clone, Copy, PartialEq, Eq, TryFromPrimitive, Default)]
@@ -18,19 +29,34 @@ pub enum ActiveMode {
     Reverse = 3,
 }
 
-#[derive(Default)]
 pub struct StageEdits {
     current_mode: ActiveMode,
     rev_goal_idx: u32,
     new_goal: bool,
+}
+
+struct Globals {
     load_stagedef_hook: LoadStagedefHook,
 }
 
-impl StageEdits {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.load_stagedef_hook.hook();
-    }
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    load_stagedef_hook: LoadStagedefHook::new(),
+});
 
+impl Default for StageEdits {
+    fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.load_stagedef_hook.hook();
+        });
+        Self {
+            current_mode: Default::default(),
+            rev_goal_idx: 0,
+            new_goal: false,
+        }
+    }
+}
+
+impl StageEdits {
     pub fn select_new_goal(&mut self) {
         self.new_goal = true;
     }
@@ -120,10 +146,7 @@ impl StageEdits {
         }
     }
 
-    fn on_load_stagedef(&mut self, stage_id: u32, cx: &AppContext) {
-        self.load_stagedef_hook.call(stage_id);
-
-        let pref = &cx.pref.borrow();
+    fn on_load_stagedef(&mut self, pref: &Pref) {
         let next_mode = ActiveMode::try_from(pref.get_u8(U8Pref::StageEditVariant)).unwrap();
         self.current_mode = next_mode;
         unsafe {
@@ -131,8 +154,7 @@ impl StageEdits {
         }
     }
 
-    pub fn on_game_ready_init(&mut self, cx: &AppContext) {
-        let pref = &cx.pref.borrow();
+    pub fn on_game_ready_init(&mut self, pref: &Pref) {
         let next_mode = ActiveMode::try_from(pref.get_u8(U8Pref::StageEditVariant)).unwrap();
         if self.current_mode != next_mode {
             unsafe {
@@ -150,7 +172,7 @@ impl StageEdits {
         self.new_goal = false;
     }
 
-    pub fn tick(&mut self, _cx: &AppContext) {
+    pub fn tick(&mut self) {
         unsafe {
             match self.current_mode {
                 ActiveMode::None => {}

--- a/crates/smb2_practice_mod/src/mods/stage_edits.rs
+++ b/crates/smb2_practice_mod/src/mods/stage_edits.rs
@@ -4,7 +4,7 @@ use mkb::mkb;
 use num_enum::TryFromPrimitive;
 
 use crate::{
-    app::{with_app, AppContext},
+    app::with_app,
     hook,
     systems::pref::{Pref, U8Pref},
     utils::misc::with_mutex,

--- a/crates/smb2_practice_mod/src/mods/timer.rs
+++ b/crates/smb2_practice_mod/src/mods/timer.rs
@@ -1,10 +1,14 @@
 use mkb::mkb;
 
 use crate::{
-    app::AppContext,
-    systems::{draw, pref::BoolPref},
+    systems::{
+        draw,
+        pref::{BoolPref, Pref},
+    },
     utils::{memstore::MemStore, timerdisp},
 };
+
+use super::{freecam::Freecam, validate::Validate};
 
 pub struct Timer {
     retrace_count: u32,
@@ -25,11 +29,7 @@ impl Default for Timer {
 }
 
 impl Timer {
-    pub fn draw(&mut self, cx: &AppContext) {
-        let pref = &mut cx.pref.borrow_mut();
-        let freecam = &mut cx.freecam.borrow_mut();
-        let validate = &cx.validate.borrow();
-
+    pub fn draw(&mut self, pref: &Pref, freecam: &Freecam, validate: &Validate) {
         unsafe {
             if mkb::main_mode != mkb::MD_GAME {
                 return;

--- a/crates/smb2_practice_mod/src/mods/unlock.rs
+++ b/crates/smb2_practice_mod/src/mods/unlock.rs
@@ -1,6 +1,5 @@
 use mkb::mkb;
 
-use crate::app::AppContext;
 use crate::systems::pref::{BoolPref, Pref};
 use crate::utils::misc::for_c_arr;
 

--- a/crates/smb2_practice_mod/src/mods/unlock.rs
+++ b/crates/smb2_practice_mod/src/mods/unlock.rs
@@ -43,7 +43,7 @@ impl Unlock {
         }
     }
 
-    fn should_unlock(pref: &mut Pref) -> bool {
+    fn should_unlock(pref: &Pref) -> bool {
         unsafe {
             let game_matches =
                 mkb::DVD_GAME_NAME == [b'G' as i8, b'M' as i8, b'2' as i8, b'E' as i8];
@@ -59,8 +59,8 @@ impl Unlock {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        if self.first_frame && Self::should_unlock(&mut cx.pref.borrow_mut()) {
+    pub fn tick(&mut self, pref: &Pref) {
+        if self.first_frame && Self::should_unlock(pref) {
             self.should_unlock = true;
         }
         self.first_frame = false;

--- a/crates/smb2_practice_mod/src/mods/validate.rs
+++ b/crates/smb2_practice_mod/src/mods/validate.rs
@@ -1,7 +1,10 @@
 use core::ffi::c_int;
+use critical_section::Mutex;
 use mkb::mkb;
 use mkb::{byte, Vec};
 
+use crate::app::with_app;
+use crate::utils::misc::with_mutex;
 use crate::{
     app::AppContext,
     hook,
@@ -16,28 +19,52 @@ use crate::{
 use super::physics::Physics;
 
 hook!(DidBallEnterGoalHook, ball: *mut mkb::Ball, out_stage_goal_idx: *mut c_int,
-      out_itemgroup_id: *mut c_int, out_goal_flags: *mut byte => u8, mkb::did_ball_enter_goal,
-      |ball, out_stage_goal_idx, out_itemgroup_id, out_goal_flags, cx| {
+        out_itemgroup_id: *mut c_int, out_goal_flags: *mut byte => u8, mkb::did_ball_enter_goal,
+        |ball, out_stage_goal_idx, out_itemgroup_id, out_goal_flags| {
 
-    let validate = &mut cx.validate.borrow_mut();
-    let result = validate.did_ball_enter_goal_hook.call(ball, out_stage_goal_idx,
-        out_itemgroup_id, out_goal_flags);
-    if result != 0 {
-        // Determine framesave percentage
-        validate.find_framesave(ball);
-        validate.entered_goal = result != 0;
-    }
-    result
+    let result = with_mutex(&GLOBALS, |cx| {
+        cx.did_ball_enter_goal_hook.call(ball, out_stage_goal_idx, out_itemgroup_id, out_goal_flags)
+    });
+
+    with_app(|cx| {
+        if result != 0 {
+            // Determine framesave percentage
+            cx.validate.find_framesave(ball);
+            cx.validate.entered_goal = result != 0;
+        }
+        result
+    })
 });
 
-#[derive(Default)]
+struct Globals {
+    did_ball_enter_goal_hook: DidBallEnterGoalHook,
+}
+
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    did_ball_enter_goal_hook: DidBallEnterGoalHook::new(),
+});
+
 pub struct Validate {
     framesave: u32,
     entered_goal: bool,
     used_mods: bool,
     has_paused: bool,
     loaded_savestate: bool,
-    did_ball_enter_goal_hook: DidBallEnterGoalHook,
+}
+
+impl Default for Validate {
+    fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.did_ball_enter_goal_hook.hook();
+        });
+        Self {
+            framesave: 0,
+            entered_goal: false,
+            used_mods: false,
+            has_paused: false,
+            loaded_savestate: false,
+        }
+    }
 }
 
 const INVALID_BOOL_PREFS: &[BoolPref] = &[
@@ -55,10 +82,6 @@ const INVALID_U8_PREFS: &[U8Pref] = &[
 ];
 
 impl Validate {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.did_ball_enter_goal_hook.hook();
-    }
-
     pub fn disable_invalidating_settings(pref: &mut Pref) {
         // Set all bool prefs to default
         for &invalid_pref in INVALID_BOOL_PREFS {
@@ -89,7 +112,7 @@ impl Validate {
             }
 
             // Track savestates
-            if lib_save_state.state_loaded_this_frame {
+            if lib_save_state.loaded_this_frame() {
                 self.loaded_savestate = true;
             }
 
@@ -228,7 +251,7 @@ impl Validate {
         }
     }
 
-    pub fn tick(&mut self, _cx: &AppContext) {
+    pub fn tick(&mut self) {
         unsafe {
             if mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT {
                 self.entered_goal = false;

--- a/crates/smb2_practice_mod/src/mods/validate.rs
+++ b/crates/smb2_practice_mod/src/mods/validate.rs
@@ -6,7 +6,6 @@ use mkb::{byte, Vec};
 use crate::app::with_app;
 use crate::utils::misc::with_mutex;
 use crate::{
-    app::AppContext,
     hook,
     systems::{
         menu_impl::MenuImpl,

--- a/crates/smb2_practice_mod/src/systems/binds.rs
+++ b/crates/smb2_practice_mod/src/systems/binds.rs
@@ -1,14 +1,14 @@
 use mkb::mkb;
 
-use crate::app::AppContext;
 use arrayvec::ArrayString;
 
 use super::pad::{Pad, Prio};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum EncodingType {
     SinglePress,
     ChordPress,
+    #[default]
     Invalid,
 }
 
@@ -68,6 +68,7 @@ const INPUT_DEFNS: &[InputDefn] = &[
     },
 ];
 
+#[derive(Default)]
 pub struct Binds {
     pressed: [bool; INPUT_DEFNS.len()],
     prev_pressed: [u8; 2],
@@ -76,22 +77,10 @@ pub struct Binds {
     num_prev_held: u8,
 }
 
-impl Default for Binds {
-    fn default() -> Self {
-        Self {
-            pressed: [false; INPUT_DEFNS.len()],
-            prev_pressed: [Self::INVALID; 2],
-            encoding: 0,
-            encoding_type: EncodingType::Invalid,
-            num_prev_held: 0,
-        }
-    }
-}
-
 impl Binds {
     pub const INVALID: u8 = 255;
 
-    fn get_button_values(&mut self, pad: &mut Pad) {
+    fn get_button_values(&mut self, pad: &Pad) {
         for (i, input_defn) in INPUT_DEFNS.iter().enumerate() {
             self.pressed[i] = pad.button_down(input_defn.input, Prio::High);
         }
@@ -121,8 +110,8 @@ impl Binds {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        self.get_button_values(&mut cx.pad.borrow_mut());
+    pub fn tick(&mut self, pad: &Pad) {
+        self.get_button_values(pad);
 
         let mut pressed_count = 0;
         let mut current_pressed = [Self::INVALID; 2];
@@ -185,7 +174,7 @@ impl Binds {
         }
     }
 
-    pub fn bind_pressed(&self, bind_id: u8, priority: Prio, pad: &mut Pad) -> bool {
+    pub fn bind_pressed(&self, bind_id: u8, priority: Prio, pad: &Pad) -> bool {
         if bind_id == Self::INVALID {
             return false;
         }

--- a/crates/smb2_practice_mod/src/systems/draw.rs
+++ b/crates/smb2_practice_mod/src/systems/draw.rs
@@ -304,7 +304,7 @@ impl Draw {
         }
     }
 
-    pub fn draw(&mut self, _cx: &AppContext) {
+    pub fn draw(&mut self) {
         let notify_len = self.notify_msg_buf.chars().count();
         let draw_x = 640 - notify_len as u32 * DEBUG_CHAR_WIDTH - 12;
         let draw_y = 426;

--- a/crates/smb2_practice_mod/src/systems/draw.rs
+++ b/crates/smb2_practice_mod/src/systems/draw.rs
@@ -6,7 +6,6 @@ use core::ptr::addr_of;
 
 use arrayvec::ArrayString;
 
-use crate::app::AppContext;
 use crate::asm;
 use crate::patch;
 use ::mkb::mkb_suppl::GXPosition3f32;

--- a/crates/smb2_practice_mod/src/systems/menu_defn.rs
+++ b/crates/smb2_practice_mod/src/systems/menu_defn.rs
@@ -26,8 +26,6 @@ pub struct MenuContext<'a> {
     pub go_to_story: &'a mut GoToStory,
     pub stage_edits: &'a mut StageEdits,
     pub unlock: &'a mut Unlock,
-    // TODO?
-    // physics: &'a mut Physics,
 }
 
 pub enum AfterPush {

--- a/crates/smb2_practice_mod/src/systems/menu_impl.rs
+++ b/crates/smb2_practice_mod/src/systems/menu_impl.rs
@@ -2,7 +2,6 @@ use mkb::mkb;
 
 use arrayvec::{ArrayString, ArrayVec};
 
-use crate::app::AppContext;
 use crate::systems::draw::{self, NotifyDuration};
 use crate::utils::tinymap::TinyMap;
 use crate::utils::tinymap::TinyMapBuilder;

--- a/crates/smb2_practice_mod/src/systems/menu_impl.rs
+++ b/crates/smb2_practice_mod/src/systems/menu_impl.rs
@@ -292,18 +292,7 @@ impl MenuImpl {
         }
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let cx = &mut MenuContext {
-            pad: &mut cx.pad.borrow_mut(),
-            pref: &mut cx.pref.borrow_mut(),
-            draw: &mut cx.draw.borrow_mut(),
-            binds: &mut cx.binds.borrow_mut(),
-            cm_seg: &mut cx.cm_seg.borrow_mut(),
-            go_to_story: &mut cx.go_to_story.borrow_mut(),
-            stage_edits: &mut cx.stage_edits.borrow_mut(),
-            unlock: &mut cx.unlock.borrow_mut(),
-        };
-
+    pub fn tick(&mut self, cx: &mut MenuContext) {
         if self.binding == BindingState::Active {
             self.handle_widget_bind(cx);
             return;
@@ -630,18 +619,7 @@ impl MenuImpl {
         );
     }
 
-    pub fn draw(&self, cx: &AppContext) {
-        let cx = &mut MenuContext {
-            pad: &mut cx.pad.borrow_mut(),
-            pref: &mut cx.pref.borrow_mut(),
-            draw: &mut cx.draw.borrow_mut(),
-            binds: &mut cx.binds.borrow_mut(),
-            cm_seg: &mut cx.cm_seg.borrow_mut(),
-            go_to_story: &mut cx.go_to_story.borrow_mut(),
-            stage_edits: &mut cx.stage_edits.borrow_mut(),
-            unlock: &mut cx.unlock.borrow_mut(),
-        };
-
+    pub fn draw(&self, cx: &mut MenuContext) {
         if !self.visible {
             return;
         }

--- a/crates/smb2_practice_mod/src/systems/pad.rs
+++ b/crates/smb2_practice_mod/src/systems/pad.rs
@@ -2,7 +2,7 @@ use critical_section::Mutex;
 use mkb::mkb;
 
 use crate::{
-    app::{with_app, AppContext},
+    app::with_app,
     hook,
     utils::misc::{for_c_arr_idx, with_mutex},
 };
@@ -79,9 +79,7 @@ static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
     pad_read_hook: PadReadHook::new(),
 });
 
-#[derive(Default)]
 pub struct Pad {
-    pad_read_hook: PadReadHook,
     analog_state: AnalogState,
     curr_priority: Prio,
     priority_request: Prio,
@@ -95,11 +93,28 @@ pub struct Pad {
     dir_down_time: [u8; 8],
 }
 
-impl Pad {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.pad_read_hook.hook();
-    }
+impl Default for Pad {
+    fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.pad_read_hook.hook();
+        });
+        Self {
+            analog_state: Default::default(),
+            curr_priority: Default::default(),
+            priority_request: Default::default(),
 
+            merged_analog_inputs: Default::default(),
+            merged_digital_inputs: Default::default(),
+            pad_status_groups: Default::default(),
+            original_inputs: Default::default(),
+            analog_inputs: Default::default(),
+
+            dir_down_time: Default::default(),
+        }
+    }
+}
+
+impl Pad {
     pub fn get_merged_stick(&self) -> StickState {
         StickState {
             x: self.analog_state.stick_x,

--- a/crates/smb2_practice_mod/src/systems/pref.rs
+++ b/crates/smb2_practice_mod/src/systems/pref.rs
@@ -9,7 +9,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use super::{
     cardio::CardIo,
-    draw::{self},
+    draw::{self, Draw},
 };
 
 macro_rules! pref_defn {
@@ -422,9 +422,7 @@ impl Pref {
         self.curr_state = self.default_state.clone();
     }
 
-    pub fn tick(&mut self, cx: &AppContext) {
-        let draw = &mut cx.draw.borrow_mut();
-
+    pub fn tick(&mut self, draw: &mut Draw) {
         self.cardio.tick();
         // Runs after all prefs have been set on a frame
         self.prev_state = self.curr_state.clone();

--- a/crates/smb2_practice_mod/src/systems/pref.rs
+++ b/crates/smb2_practice_mod/src/systems/pref.rs
@@ -1,13 +1,7 @@
 extern crate alloc;
-use core::cell::Cell;
-
 use ::mkb::mkb_suppl::CARDResult;
 
-use crate::{
-    app::{with_global_cx, AppContext},
-    cstr, fmt,
-    systems::draw::NotifyDuration,
-};
+use crate::{app::AppContext, cstr, fmt, systems::draw::NotifyDuration};
 use alloc::vec;
 use alloc::vec::Vec;
 use num_enum::TryFromPrimitive;
@@ -207,19 +201,8 @@ struct DefaultU8 {
 
 #[derive(Clone, Default)]
 struct PrefState {
-    bools: [Cell<u8>; get_bit_array_len(BOOL_PREF_COUNT)],
-    u8s: [Cell<u8>; U8_PREF_COUNT],
-}
-
-impl PrefState {
-    fn copy_from(&self, other: &PrefState) {
-        for (curr, other) in self.bools.iter().zip(other.bools.iter()) {
-            curr.set(other.get());
-        }
-        for (curr, other) in self.u8s.iter().zip(other.u8s.iter()) {
-            curr.set(other.get());
-        }
-    }
+    bools: [u8; get_bit_array_len(BOOL_PREF_COUNT)],
+    u8s: [u8; U8_PREF_COUNT],
 }
 
 #[repr(C, packed)]
@@ -267,99 +250,28 @@ where
 
 pub struct Pref {
     cardio: CardIo,
-    pref_buf: Option<Vec<u8>>,
-    import_error: Option<&'static str>,
-}
-
-// Globally accessible pref store
-#[derive(Default)]
-pub struct PrefDb {
     curr_state: PrefState,
     prev_state: PrefState,
     default_state: PrefState,
-    save_queued: Cell<bool>,
-}
-
-impl PrefDb {
-    pub fn get_bool(&self, bool_pref: BoolPref) -> bool {
-        Self::get_bool_pref(bool_pref, &self.curr_state)
-    }
-
-    pub fn get_u8(&self, u8_pref: U8Pref) -> u8 {
-        Self::get_u8_pref(u8_pref, &self.curr_state)
-    }
-
-    pub fn set_bool(&self, bool_pref: BoolPref, val: bool) {
-        Self::set_bool_pref(bool_pref, &self.curr_state, val);
-    }
-
-    pub fn set_u8(&self, u8_pref: U8Pref, val: u8) {
-        Self::set_u8_pref(u8_pref, &self.curr_state, val);
-    }
-
-    pub fn did_change_bool(&self, bool_pref: BoolPref) -> bool {
-        let curr = Self::get_bool_pref(bool_pref, &self.curr_state);
-        let prev = Self::get_bool_pref(bool_pref, &self.prev_state);
-        curr != prev
-    }
-
-    pub fn did_change_u8(&self, u8_pref: U8Pref) -> bool {
-        let curr = Self::get_u8_pref(u8_pref, &self.curr_state);
-        let prev = Self::get_u8_pref(u8_pref, &self.prev_state);
-        curr != prev
-    }
-
-    pub fn get_default_bool(&self, bool_pref: BoolPref) -> bool {
-        Self::get_bool_pref(bool_pref, &self.default_state)
-    }
-
-    pub fn get_default_u8(&self, u8_pref: U8Pref) -> u8 {
-        Self::get_u8_pref(u8_pref, &self.default_state)
-    }
-
-    pub fn reset_all_defaults(&self) {
-        self.curr_state.copy_from(&self.default_state);
-    }
-
-    pub fn save(&self) {
-        self.save_queued.set(true);
-    }
-
-    fn get_bool_pref(bool_pref: BoolPref, state: &PrefState) -> bool {
-        let val = state.bools[bool_pref as usize / 8].get() & (1 << (bool_pref as usize % 8));
-        val > 0
-    }
-
-    fn get_u8_pref(u8_pref: U8Pref, state: &PrefState) -> u8 {
-        state.u8s[u8_pref as usize].get()
-    }
-
-    fn set_bool_pref(bool_pref: BoolPref, state: &PrefState, val: bool) {
-        let current = &state.bools[bool_pref as usize / 8];
-        if val {
-            current.set(current.get() | 1 << (bool_pref as usize % 8));
-        } else {
-            current.set(current.get() & !(1 << (bool_pref as usize % 8)));
-        }
-    }
-
-    fn set_u8_pref(u8_pref: U8Pref, state: &PrefState, val: u8) {
-        state.u8s[u8_pref as usize].set(val);
-    }
+    pref_buf: Option<Vec<u8>>,
+    import_error: Option<&'static str>,
+    save_queued: bool,
 }
 
 impl Default for Pref {
     fn default() -> Self {
         let mut pref = Self {
             cardio: CardIo::new(),
+            curr_state: PrefState::default(),
+            prev_state: PrefState::default(),
+            default_state: PrefState::default(),
             pref_buf: Some(vec![0; PREF_BUF_SIZE]),
             import_error: None,
+            save_queued: false,
         };
 
-        Self::load_default_prefs();
-        with_global_cx(|cx| {
-            cx.pref.prev_state.copy_from(&cx.pref.default_state);
-        });
+        pref.load_default_prefs();
+        pref.prev_state = pref.default_state.clone();
         match pref.cardio.read_file(PREF_FILENAME) {
             Ok(mut buf) => {
                 pref.import_from_card_buf(&mut buf);
@@ -393,15 +305,13 @@ impl Pref {
                 value: 0,
             };
 
-            with_global_cx(|cx| {
-                if let Some(bool_pref) = Self::pref_id_to_bool_pref(pref_id) {
-                    entry.value = cx.pref.get_bool(bool_pref) as u16;
-                } else if let Some(u8_pref) = Self::pref_id_to_u8_pref(pref_id) {
-                    entry.value = cx.pref.get_u8(u8_pref) as u16;
-                } else {
-                    panic!("Failed to determine preference type");
-                }
-            });
+            if let Some(bool_pref) = Self::pref_id_to_bool_pref(pref_id) {
+                entry.value = self.get_bool(bool_pref) as u16;
+            } else if let Some(u8_pref) = Self::pref_id_to_u8_pref(pref_id) {
+                entry.value = self.get_u8(u8_pref) as u16;
+            } else {
+                panic!("Failed to determine preference type");
+            }
 
             buf = append_to_byte_slice(buf, &entry);
         }
@@ -419,39 +329,97 @@ impl Pref {
             return; // Preferences file format too new for this mod
         }
 
-        with_global_cx(|cx| {
-            for _ in 0..header.num_prefs {
-                let entry;
-                (entry, buf) = read_from_byte_slice::<FilePrefEntry>(buf);
-                if let Ok(pref_id) = PrefId::try_from(entry.id) {
-                    if let Some(bool_pref) = Self::pref_id_to_bool_pref(pref_id) {
-                        PrefDb::set_bool_pref(bool_pref, &cx.pref.curr_state, entry.value > 0);
-                    } else if let Some(u8_pref) = Self::pref_id_to_u8_pref(pref_id) {
-                        PrefDb::set_u8_pref(
-                            u8_pref,
-                            &cx.pref.curr_state,
-                            entry.value.try_into().unwrap_or(0),
-                        );
-                    } else {
-                        // Unknown preference type somehow, ignore
-                    }
+        for _ in 0..header.num_prefs {
+            let entry;
+            (entry, buf) = read_from_byte_slice::<FilePrefEntry>(buf);
+            if let Ok(pref_id) = PrefId::try_from(entry.id) {
+                if let Some(bool_pref) = Self::pref_id_to_bool_pref(pref_id) {
+                    Self::set_bool_pref(bool_pref, &mut self.curr_state, entry.value > 0);
+                } else if let Some(u8_pref) = Self::pref_id_to_u8_pref(pref_id) {
+                    Self::set_u8_pref(
+                        u8_pref,
+                        &mut self.curr_state,
+                        entry.value.try_into().unwrap_or(0),
+                    );
                 } else {
-                    // Unknown pref ID, ignore
+                    // Unknown preference type somehow, ignore
                 }
+            } else {
+                // Unknown pref ID, ignore
             }
-        });
+        }
     }
 
-    fn load_default_prefs() {
-        with_global_cx(|cx| {
-            for default_bool in DEFAULT_BOOLS {
-                PrefDb::set_bool_pref(default_bool.id, &cx.pref.default_state, default_bool.value);
-            }
-            for default_u8 in DEFAULT_U8S {
-                PrefDb::set_u8_pref(default_u8.id, &cx.pref.default_state, default_u8.value);
-            }
-            cx.pref.curr_state.copy_from(&cx.pref.default_state);
-        });
+    fn load_default_prefs(&mut self) {
+        self.default_state = PrefState::default(); // Zero
+        for default_bool in DEFAULT_BOOLS {
+            Self::set_bool_pref(default_bool.id, &mut self.default_state, default_bool.value);
+        }
+        for default_u8 in DEFAULT_U8S {
+            Self::set_u8_pref(default_u8.id, &mut self.default_state, default_u8.value);
+        }
+        self.curr_state = self.default_state.clone();
+    }
+
+    fn get_bool_pref(bool_pref: BoolPref, state: &PrefState) -> bool {
+        let val = state.bools[bool_pref as usize / 8] & (1 << (bool_pref as usize % 8));
+        val > 0
+    }
+
+    fn get_u8_pref(u8_pref: U8Pref, state: &PrefState) -> u8 {
+        state.u8s[u8_pref as usize]
+    }
+
+    fn set_bool_pref(bool_pref: BoolPref, state: &mut PrefState, val: bool) {
+        if val {
+            state.bools[bool_pref as usize / 8] |= 1 << (bool_pref as usize % 8);
+        } else {
+            state.bools[bool_pref as usize / 8] &= !(1 << (bool_pref as usize % 8));
+        }
+    }
+
+    fn set_u8_pref(u8_pref: U8Pref, state: &mut PrefState, val: u8) {
+        state.u8s[u8_pref as usize] = val;
+    }
+
+    pub fn get_bool(&self, bool_pref: BoolPref) -> bool {
+        Self::get_bool_pref(bool_pref, &self.curr_state)
+    }
+
+    pub fn get_u8(&self, u8_pref: U8Pref) -> u8 {
+        Self::get_u8_pref(u8_pref, &self.curr_state)
+    }
+
+    pub fn set_bool(&mut self, bool_pref: BoolPref, val: bool) {
+        Self::set_bool_pref(bool_pref, &mut self.curr_state, val);
+    }
+
+    pub fn set_u8(&mut self, u8_pref: U8Pref, val: u8) {
+        Self::set_u8_pref(u8_pref, &mut self.curr_state, val);
+    }
+
+    pub fn did_change_bool(&self, bool_pref: BoolPref) -> bool {
+        let curr = Self::get_bool_pref(bool_pref, &self.curr_state);
+        let prev = Self::get_bool_pref(bool_pref, &self.prev_state);
+        curr != prev
+    }
+
+    pub fn did_change_u8(&self, u8_pref: U8Pref) -> bool {
+        let curr = Self::get_u8_pref(u8_pref, &self.curr_state);
+        let prev = Self::get_u8_pref(u8_pref, &self.prev_state);
+        curr != prev
+    }
+
+    pub fn get_default_bool(&self, bool_pref: BoolPref) -> bool {
+        Self::get_bool_pref(bool_pref, &self.default_state)
+    }
+
+    pub fn get_default_u8(&self, u8_pref: U8Pref) -> u8 {
+        Self::get_u8_pref(u8_pref, &self.default_state)
+    }
+
+    pub fn reset_all_defaults(&mut self) {
+        self.curr_state = self.default_state.clone();
     }
 
     pub fn tick(&mut self, cx: &AppContext) {
@@ -459,9 +427,7 @@ impl Pref {
 
         self.cardio.tick();
         // Runs after all prefs have been set on a frame
-        with_global_cx(|cx| {
-            cx.pref.prev_state.copy_from(&cx.pref.curr_state);
-        });
+        self.prev_state = self.curr_state.clone();
 
         if let Some(err) = self.import_error {
             draw.notify(draw::RED, NotifyDuration::Long, err);
@@ -487,14 +453,16 @@ impl Pref {
         }
 
         // Start a write if a save is pending and a write is not pending
-        with_global_cx(|cx| {
-            if cx.pref.save_queued.get() {
-                if let Some(mut buf) = self.pref_buf.take() {
-                    self.export_to_card_buf(&mut buf);
-                    self.cardio.begin_write_file(PREF_FILENAME, buf);
-                    cx.pref.save_queued.set(false);
-                }
+        if self.save_queued {
+            if let Some(mut buf) = self.pref_buf.take() {
+                self.export_to_card_buf(&mut buf);
+                self.cardio.begin_write_file(PREF_FILENAME, buf);
+                self.save_queued = false;
             }
-        });
+        }
+    }
+
+    pub fn save(&mut self) {
+        self.save_queued = true;
     }
 }

--- a/crates/smb2_practice_mod/src/systems/pref.rs
+++ b/crates/smb2_practice_mod/src/systems/pref.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 use ::mkb::mkb_suppl::CARDResult;
 
-use crate::{app::AppContext, cstr, fmt, systems::draw::NotifyDuration};
+use crate::{cstr, fmt, systems::draw::NotifyDuration};
 use alloc::vec;
 use alloc::vec::Vec;
 use num_enum::TryFromPrimitive;

--- a/crates/smb2_practice_mod/src/utils/hook.rs
+++ b/crates/smb2_practice_mod/src/utils/hook.rs
@@ -2,48 +2,50 @@
 macro_rules! hook {
     ($name:ident $(, $argname:ident: $arg:ty)* => $ret:ty, $their_func:expr, $our_func:expr) => {
         pub struct $name {
-            instrs: [usize; 2],
-            chained_func: Option<extern "C" fn($($arg,)*) -> $ret>,
+            instrs: [core::cell::Cell<usize>; 2],
+            chained_func: core::cell::Cell<Option<extern "C" fn($($arg,)*) -> $ret>>,
             their_func: unsafe extern "C" fn($($arg,)*) -> $ret,
             our_func_c: extern "C" fn($($arg,)*) -> $ret,
         }
 
         impl Default for $name {
             fn default() -> Self {
-                Self {
-                    instrs: [0, 0],
-                    chained_func: None,
-                    their_func: $their_func,
-                    our_func_c: Self::c_hook,
-                }
+                Self::new()
             }
         }
 
         impl $name {
-            pub fn hook(&mut self) {
+            const fn new() -> Self {
+                Self {
+                    instrs: [core::cell::Cell::new(0), core::cell::Cell::new(0)],
+                    chained_func: core::cell::Cell::new(None),
+                    their_func: $their_func,
+                    our_func_c: Self::c_hook,
+                }
+            }
+
+            pub fn hook(&self) {
                 unsafe {
                     let mut chained_func_addr = core::ptr::null();
                     $crate::patch::hook_function(
                         self.their_func as *mut usize,
                         self.our_func_c as *mut usize,
-                        &mut self.instrs,
+                        &self.instrs,
                         &mut chained_func_addr,
                     );
-                    self.chained_func = Some(core::mem::transmute(chained_func_addr));
+                    self.chained_func.set(Some(core::mem::transmute(chained_func_addr)));
                 }
             }
 
             // We sometimes want to replace the hooked function entirely and never call the original
             #[allow(dead_code)]
             pub fn call(&self $(, $argname: $arg)*) -> $ret {
-                (self.chained_func.unwrap())($($argname,)*)
+                (self.chained_func.get().unwrap())($($argname,)*)
             }
 
             extern "C" fn c_hook($($argname: $arg, )*) -> $ret {
-                let f: fn($($arg,)* &$crate::app::AppContext) -> $ret = $our_func;
-                critical_section::with(|cs| {
-                    f($($argname, )* $crate::app::APP_CONTEXT.borrow(cs))
-                })
+                let f: fn($($arg,)*) -> $ret = $our_func;
+                f($($argname, )*)
             }
         }
     }

--- a/crates/smb2_practice_mod/src/utils/libsavestate.rs
+++ b/crates/smb2_practice_mod/src/utils/libsavestate.rs
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{hook, mods::timer::Timer};
 
-// Reentrant hook, cannot use app state
+// Re-entrant hook, cannot use app state
 hook!(SoundReqIdHook, sfx_idx: u32 => (), mkb::call_SoundReqID_arg_0, |sfx_idx| {
     with_mutex(&GLOBALS, |cx| {
         if !cx.state_loaded_this_frame.get() {

--- a/crates/smb2_practice_mod/src/utils/libsavestate.rs
+++ b/crates/smb2_practice_mod/src/utils/libsavestate.rs
@@ -1,25 +1,47 @@
-use core::ffi::c_void;
+use core::{cell::Cell, ffi::c_void};
+use critical_section::Mutex;
 use mkb::mkb;
+use once_cell::sync::Lazy;
 
-use super::memstore::{self, MemStore};
-use crate::{app::AppContext, hook, mods::timer::Timer};
+use super::{
+    memstore::{self, MemStore},
+    misc::with_mutex,
+};
+use crate::{app::with_app, hook, mods::timer::Timer};
 
-hook!(SoundReqIdHook, sfx_idx: u32 => (), mkb::call_SoundReqID_arg_0, |sfx_idx, cx| {
-    let libsavestate = &cx.lib_save_state.borrow();
-    if !libsavestate.state_loaded_this_frame {
-        cx.lib_save_state.borrow().sound_req_id_hook.call(sfx_idx);
-    }
+// Reentrant hook, cannot use app state
+hook!(SoundReqIdHook, sfx_idx: u32 => (), mkb::call_SoundReqID_arg_0, |sfx_idx| {
+    with_mutex(&GLOBALS, |cx| {
+        if !cx.state_loaded_this_frame.get() {
+            cx.sound_req_id_hook.call(sfx_idx);
+        }
+    });
 });
 
-#[derive(Default)]
-pub struct LibSaveState {
+struct Globals {
     sound_req_id_hook: SoundReqIdHook,
-    pub state_loaded_this_frame: bool,
+    state_loaded_this_frame: Cell<bool>,
+}
+
+static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
+    sound_req_id_hook: SoundReqIdHook::new(),
+    state_loaded_this_frame: Cell::new(false),
+});
+
+pub struct LibSaveState {}
+
+impl Default for LibSaveState {
+    fn default() -> Self {
+        with_mutex(&GLOBALS, |cx| {
+            cx.sound_req_id_hook.hook();
+        });
+        Self {}
+    }
 }
 
 impl LibSaveState {
-    pub fn on_main_loop_load(&mut self, _cx: &AppContext) {
-        self.sound_req_id_hook.hook();
+    pub fn loaded_this_frame(&self) -> bool {
+        with_mutex(&GLOBALS, |cx| cx.state_loaded_this_frame.get())
     }
 }
 
@@ -60,7 +82,9 @@ pub struct SaveState {
 
 impl SaveState {
     pub fn tick(&mut self, libsavestate: &mut LibSaveState, timer: &mut Timer) {
-        libsavestate.state_loaded_this_frame = false;
+        with_mutex(&GLOBALS, |cx| {
+            cx.state_loaded_this_frame.set(false);
+        });
         if self.reload_state {
             let _ = self.load(libsavestate, timer); // Ignore result, spooky!
         }
@@ -188,7 +212,9 @@ impl SaveState {
                 mkb::set_minimap_mode(mkb::MINIMAP_EXPAND);
             }
 
-            libsavestate.state_loaded_this_frame = true;
+            with_mutex(&GLOBALS, |cx| {
+                cx.state_loaded_this_frame.set(true);
+            });
         }
 
         Ok(())

--- a/crates/smb2_practice_mod/src/utils/libsavestate.rs
+++ b/crates/smb2_practice_mod/src/utils/libsavestate.rs
@@ -1,13 +1,12 @@
 use core::{cell::Cell, ffi::c_void};
 use critical_section::Mutex;
 use mkb::mkb;
-use once_cell::sync::Lazy;
 
 use super::{
     memstore::{self, MemStore},
     misc::with_mutex,
 };
-use crate::{app::with_app, hook, mods::timer::Timer};
+use crate::{hook, mods::timer::Timer};
 
 // Reentrant hook, cannot use app state
 hook!(SoundReqIdHook, sfx_idx: u32 => (), mkb::call_SoundReqID_arg_0, |sfx_idx| {

--- a/crates/smb2_practice_mod/src/utils/libsavestate.rs
+++ b/crates/smb2_practice_mod/src/utils/libsavestate.rs
@@ -80,12 +80,12 @@ pub struct SaveState {
 }
 
 impl SaveState {
-    pub fn tick(&mut self, libsavestate: &mut LibSaveState, timer: &mut Timer) {
+    pub fn tick(&mut self, timer: &mut Timer) {
         with_mutex(&GLOBALS, |cx| {
             cx.state_loaded_this_frame.set(false);
         });
         if self.reload_state {
-            let _ = self.load(libsavestate, timer); // Ignore result, spooky!
+            let _ = self.load(timer); // Ignore result, spooky!
         }
     }
 
@@ -154,11 +154,7 @@ impl SaveState {
         }
     }
 
-    pub fn load(
-        &mut self,
-        libsavestate: &mut LibSaveState,
-        timer: &mut Timer,
-    ) -> Result<(), LoadError> {
+    pub fn load(&mut self, timer: &mut Timer) -> Result<(), LoadError> {
         unsafe {
             // Must be in main game
             if mkb::main_mode != mkb::MD_GAME {

--- a/crates/smb2_practice_mod/src/utils/misc.rs
+++ b/crates/smb2_practice_mod/src/utils/misc.rs
@@ -1,3 +1,5 @@
+use critical_section::Mutex;
+
 // Iterate a static mutable array (in mkb) without creating a reference
 pub fn for_c_arr<const N: usize, T, F>(ptr: *mut [T; N], mut f: F)
 where
@@ -15,4 +17,8 @@ where
     for i in 0..N {
         f(i, unsafe { &raw mut (*ptr)[i] });
     }
+}
+
+pub fn with_mutex<T, R>(m: &Mutex<T>, f: impl FnOnce(&T) -> R) -> R {
+    critical_section::with(|cs| f(m.borrow(cs)))
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -7,9 +7,10 @@ use gamecube_tools::elf2rel::RelVersion;
 
 // We don't read from the CARGO environment variable because we want to use the one in PATH. It
 // allows selecting a different toolchain with +nightly
+// TODO is this still relevant?
 const CARGO_PATH: &str = "cargo";
 
-const CARGO_COMMON: &[&str] = &["+nightly", "build", "-p", "smb2_practice_mod", "--release"];
+const CARGO_COMMON: &[&str] = &["build", "-p", "smb2_practice_mod", "--release"];
 
 const CARGO_BASE_RELEASE: &[&str] = &[
     "-Z",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2024-11-27"
+components = ["rust-src"]


### PR DESCRIPTION
Currently, each instance of a module is stored in its own `RefCell` which:

1) Allows modules to (possibly mutably) access other modules arbitrarily
2) Allows hooked callbacks from SMB2 to call back into modules, which AFAIK _must_ somehow be connected to global mutable state to function

Unfortunately, the scope of runtime-derived references to `RefCell`'d items ends up being complex and interwoven. I've found that encountering double-borrow errors at runtime has been common and simultaneously difficult to predict. I think there are currently at least three double-borrow bugs lurking, and I can only reproduce one of them.

At this point, I just want to eliminate this class of bugs entirely. My rough plan is to make modules communicate by mutating a global state deliberately limited to just the state which needs to be shared. This state would provide interior mutability through `Cell` instead of `RefCell`, which means that direct references to mutable state cannot be created in the first place.

Although this is kinda sorta introducing a big global variable, there's still encapsulation going on. Modules can define a shared-state struct specific to them with a public API for other modules, while still being able to access everything in the struct from inside the parent module.

---

I ended up going with a different approach. I realized it's actually not a problem for all hooks to access the single global state (via RefCell), assuming these conditions are met:

1. The global state is not held when executing the hook's `call()` function
2. The hook is not "re-entrant" - called transitively by another hook (while global state is held)

1 requires moving hooks into separate global state so they can be `call()`ed without holding global state. For 2, re-entrant hooks simply access the state they need via, again, separate global state.

As it turned out, this minimized the amount of state that needed to be separated out. There are only three re-entrant hooks, two of them for the SMB2 function to play a sound and one for the SMB2 function to toggle the minimap zoom. Somehow, this change also saved around 8KB! Maybe removing `Lazy`s and `RefCell`s helped out a lot?

I also pinned the Rust toochain version via `rust-toolchain.toml`. I plan a follow-up PR that cleans up the new clippy lints introduced, and I'll also try to see if `xtask` can easily be built with the stable toolchain.

Testing has been minimal - I plan to do some console testing after I finish the other PR.
