### PR TITLE
Savestates UI improvements

### DIFF
--- a/crates/smb2_practice_mod/src/app.rs
+++ b/crates/smb2_practice_mod/src/app.rs
@@ -104,7 +104,8 @@ hook!(ProcessInputsHook => (), mkb::process_inputs, || {
         cx.binds.tick(&cx.pad);
         cx.unlock.tick(&cx.pref);
         cx.iw.tick(&cx.pad);
-        cx.save_states_ui.tick(&cx.pref, &cx.pad, &mut cx.draw, &cx.binds, &mut cx.timer);
+        cx.lib_save_state.tick();
+        cx.save_states_ui.tick(&cx.lib_save_state, &cx.pref, &cx.pad, &mut cx.draw, &cx.binds, &mut cx.timer);
         let mut menu_context = MenuContext {
             pad: &mut cx.pad,
             pref: &mut cx.pref,

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -1,7 +1,14 @@
+// TODO:
+// Maybe try to see why size jumped up by 8kb?
+// Make sure stuff works with frame advance
+// Don't spam notifications while holding a button
+// Add menu bind for clearing all savestates (and resets selected slot to 1)
+
 use core::cell::Cell;
 
 use critical_section::Mutex;
 use mkb::mkb;
+use num_enum::TryFromPrimitive;
 
 use crate::{
     fmt, hook,
@@ -12,7 +19,7 @@ use crate::{
         pref::{BoolPref, Pref, U8Pref},
     },
     utils::{
-        libsavestate::{LoadError, SaveError, SaveState},
+        libsavestate::{LibSaveState, LoadError, SaveError, SaveState},
         misc::with_mutex,
     },
 };
@@ -45,6 +52,7 @@ hook!(SetMinimapModeHook, mode: mkb::MinimapMode => (), mkb::set_minimap_mode, |
 });
 
 struct Context<'a> {
+    lib_save_state: &'a LibSaveState,
     pref: &'a Pref,
     pad: &'a Pad,
     draw: &'a mut Draw,
@@ -52,9 +60,17 @@ struct Context<'a> {
     timer: &'a mut Timer,
 }
 
+#[derive(TryFromPrimitive)]
+#[repr(u8)]
+enum SaveTo {
+    Selected,
+    NextEmpty,
+    NextEmptyThenOldest,
+}
+
 pub struct SaveStatesUi {
     states: [SaveState; 8],
-    active_state_slot: i32,
+    active_state_slot: usize,
     created_state_last_frame: bool,
     frame_advance_mode: bool,
 }
@@ -79,8 +95,216 @@ impl SaveStatesUi {
             || pad.analog_down(mkb::PAI_RTRIG as mkb::PadAnalogInput, Prio::Low)
     }
 
+    fn find_next_empty(&self) -> Option<usize> {
+        for i in 0..self.states.len() {
+            let slot_idx = (self.active_state_slot + i) % self.states.len();
+            if self.states[slot_idx].is_empty() {
+                return Some(slot_idx);
+            }
+        }
+        None
+    }
+
+    fn pick_save_slot(&self, cx: &mut Context) -> Option<usize> {
+        let save_to = SaveTo::try_from(cx.pref.get_u8(U8Pref::SavestateSaveTo)).unwrap();
+        match save_to {
+            SaveTo::Selected => Some(self.active_state_slot),
+            SaveTo::NextEmpty => self.find_next_empty(),
+            SaveTo::NextEmptyThenOldest => {
+                let next_empty = self.find_next_empty();
+                if next_empty.is_some() {
+                    return next_empty;
+                }
+
+                let mut oldest_idx = 0;
+                for i in 0..self.states.len() {
+                    if self.states[i].timestamp() < self.states[oldest_idx].timestamp() {
+                        oldest_idx = i;
+                    }
+                }
+                Some(oldest_idx)
+            }
+        }
+    }
+
+    fn save_slot(&mut self, cx: &mut Context) {
+        let Some(slot_idx) = self.pick_save_slot(cx) else {
+            cx.draw.notify(
+                draw::RED,
+                NotifyDuration::Short,
+                "Cannot Create Savestate: No Slots Left",
+            );
+            return;
+        };
+        let state = &mut self.states[slot_idx];
+
+        if let Err(code) = state.save(cx.lib_save_state, cx.timer) {
+            match code {
+                SaveError::MainMode => {
+                    // Unreachable
+                    panic!("Unreachable state in savestate save");
+                }
+                SaveError::PostFallout => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Create Savestate After Fallout",
+                    );
+                }
+                SaveError::PostGoal => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Create Savestate After Goal",
+                    );
+                }
+                SaveError::DuringRetry => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Create Savestate During Retry",
+                    );
+                }
+                SaveError::PostTimeout => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Create Savestate After Timeout",
+                    );
+                }
+                SaveError::SubMode => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Create Savestate Here",
+                    );
+                }
+                SaveError::ViewStage => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Create Savestate in View Stage",
+                    );
+                }
+                SaveError::InsufficientMemory => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Create Savestate: Not Enough Memory",
+                    );
+                }
+            }
+            return;
+        }
+
+        self.active_state_slot = slot_idx;
+        self.frame_advance_mode = self.is_either_trigger_held(cx.pad);
+        if self.frame_advance_mode {
+            cx.draw.notify(
+                draw::PINK,
+                NotifyDuration::Short,
+                &fmt!(32, c"Slot %d Frame Advance", self.active_state_slot + 1),
+            );
+        } else {
+            cx.draw.notify(
+                draw::PINK,
+                NotifyDuration::Short,
+                &fmt!(32, c"Slot %d Saved", self.active_state_slot + 1),
+            );
+        }
+
+        self.created_state_last_frame = true;
+    }
+
+    fn clear_slot(&mut self, cx: &mut Context) {
+        let state = &mut self.states[self.active_state_slot];
+        state.clear(cx.lib_save_state);
+        cx.draw.notify(
+            draw::BLUE,
+            NotifyDuration::Short,
+            &fmt!(32, c"Slot %d Cleared", self.active_state_slot + 1),
+        );
+    }
+
+    fn load_slot(&mut self, cx: &mut Context) {
+        let state = &mut self.states[self.active_state_slot];
+        match state.load(cx.lib_save_state, cx.timer) {
+            Ok(()) => {}
+            Err(LoadError::MainMode) => {
+                // Unreachable
+                panic!("Unreachable state in savestate load");
+            }
+            Err(LoadError::SubMode) => {
+                cx.draw.notify(
+                    draw::RED,
+                    NotifyDuration::Short,
+                    "Cannot Load Savestate Here",
+                );
+                return;
+            }
+            Err(LoadError::TimeOver) => {
+                cx.draw.notify(
+                    draw::RED,
+                    NotifyDuration::Short,
+                    "Cannot Load Savestate After Time Over",
+                );
+                return;
+            }
+            Err(LoadError::Empty) => {
+                cx.draw.notify(
+                    draw::RED,
+                    NotifyDuration::Short,
+                    &fmt!(32, c"Slot %d Empty", self.active_state_slot + 1),
+                );
+                return;
+            }
+            Err(LoadError::WrongStage) => {
+                cx.draw.notify(
+                    draw::RED,
+                    NotifyDuration::Short,
+                    &fmt!(32, c"Slot %d Wrong Stage", self.active_state_slot + 1),
+                );
+                return;
+            }
+            Err(LoadError::WrongMonkey) => {
+                // Thank you StevenCW for finding this marvelous bug
+                cx.draw.notify(
+                    draw::RED,
+                    NotifyDuration::Short,
+                    &fmt!(32, c"Slot %d Wrong Monkey", self.active_state_slot + 1),
+                );
+                return;
+            }
+            Err(LoadError::ViewStage) => {
+                cx.draw.notify(
+                    draw::RED,
+                    NotifyDuration::Short,
+                    &fmt!(32, c"Cannot Load Savestate in View Stage"),
+                );
+                return;
+            }
+            Err(LoadError::PausedAndNonGameplaySubmode) => {
+                cx.draw.notify(
+                    draw::RED,
+                    NotifyDuration::Short,
+                    &fmt!(32, c"Cannot Load Savestate, Please Unpause"),
+                );
+                return;
+            }
+        }
+
+        if !self.created_state_last_frame {
+            cx.draw.notify(
+                draw::BLUE,
+                NotifyDuration::Short,
+                &fmt!(32, c"Slot %d Loaded", self.active_state_slot + 1),
+            );
+        }
+    }
+
     pub fn tick(
         &mut self,
+        lib_save_state: &LibSaveState,
         pref: &Pref,
         pad: &Pad,
         draw: &mut Draw,
@@ -88,6 +312,7 @@ impl SaveStatesUi {
         timer: &mut Timer,
     ) {
         let cx = &mut Context {
+            lib_save_state,
             pref,
             pad,
             draw,
@@ -102,12 +327,11 @@ impl SaveStatesUi {
         if !savestates_enabled(cx.pref) {
             return;
         }
-        let disable_overwrite = pref.get_bool(BoolPref::SavestateDisableOverwrite);
         let clear_bind = pref.get_u8(U8Pref::SavestateClearBind);
 
         // Must tick savestates every frame
         for state in &mut self.states {
-            state.tick(cx.timer);
+            state.tick(cx.lib_save_state, cx.timer);
         }
 
         if !self.is_either_trigger_held(cx.pad) {
@@ -122,7 +346,7 @@ impl SaveStatesUi {
         // Change the savestate slot with C stick
         let cstick_dir = cx.pad.get_cstick_dir(Prio::Low);
         if cstick_dir != Dir::None {
-            self.active_state_slot = cstick_dir as i32;
+            self.active_state_slot = cstick_dir as usize;
             cx.draw.notify(
                 draw::WHITE,
                 NotifyDuration::Short,
@@ -134,105 +358,9 @@ impl SaveStatesUi {
             .pad
             .button_pressed(mkb::PAD_BUTTON_X as mkb::PadDigitalInput, Prio::Low)
         {
-            let state = &mut self.states[self.active_state_slot as usize];
-
-            if !state.is_empty() && disable_overwrite {
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Slot %d Full", self.active_state_slot + 1),
-                );
-                return;
-            }
-
-            match state.save(cx.timer) {
-                Ok(()) => {}
-                Err(SaveError::MainMode) => {
-                    // Unreachable
-                    panic!("Unreachable state in savestate save");
-                }
-                Err(SaveError::PostFallout) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Create Savestate After Fallout",
-                    );
-                    return;
-                }
-                Err(SaveError::PostGoal) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Create Savestate After Goal",
-                    );
-                    return;
-                }
-                Err(SaveError::DuringRetry) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Create Savestate During Retry",
-                    );
-                    return;
-                }
-                Err(SaveError::PostTimeout) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Create Savestate After Timeout",
-                    );
-                    return;
-                }
-                Err(SaveError::SubMode) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Create Savestate Here",
-                    );
-                    return;
-                }
-                Err(SaveError::ViewStage) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Create Savestate in View Stage",
-                    );
-                    return;
-                }
-                Err(SaveError::InsufficientMemory) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Create Savestate: Not Enough Memory",
-                    );
-                    return;
-                }
-            }
-
-            self.frame_advance_mode = self.is_either_trigger_held(cx.pad);
-            if self.frame_advance_mode {
-                cx.draw.notify(
-                    draw::PINK,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Slot %d Frame Advance", self.active_state_slot + 1),
-                );
-            } else {
-                cx.draw.notify(
-                    draw::PINK,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Slot %d Saved", self.active_state_slot + 1),
-                );
-            }
-
-            self.created_state_last_frame = true;
+            self.save_slot(cx);
         } else if cx.binds.bind_pressed(clear_bind, Prio::Low, cx.pad) {
-            let state = &mut self.states[self.active_state_slot as usize];
-            state.clear();
-            cx.draw.notify(
-                draw::BLUE,
-                NotifyDuration::Short,
-                &fmt!(32, c"Slot %d Cleared", self.active_state_slot + 1),
-            );
+            self.clear_slot(cx);
         } else if cx
             .pad
             .button_down(mkb::PAD_BUTTON_Y as mkb::PadDigitalInput, Prio::Low)
@@ -243,79 +371,7 @@ impl SaveStatesUi {
             || self.frame_advance_mode
             || (self.is_either_trigger_held(cx.pad) && cstick_dir != Dir::None)
         {
-            let state = &mut self.states[self.active_state_slot as usize];
-            match state.load(cx.timer) {
-                Ok(()) => {}
-                Err(LoadError::MainMode) => {
-                    // Unreachable
-                    panic!("Unreachable state in savestate load");
-                }
-                Err(LoadError::SubMode) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Load Savestate Here",
-                    );
-                    return;
-                }
-                Err(LoadError::TimeOver) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        "Cannot Load Savestate After Time Over",
-                    );
-                    return;
-                }
-                Err(LoadError::Empty) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        &fmt!(32, c"Slot %d Empty", self.active_state_slot + 1),
-                    );
-                    return;
-                }
-                Err(LoadError::WrongStage) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        &fmt!(32, c"Slot %d Wrong Stage", self.active_state_slot + 1),
-                    );
-                    return;
-                }
-                Err(LoadError::WrongMonkey) => {
-                    // Thank you StevenCW for finding this marvelous bug
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        &fmt!(32, c"Slot %d Wrong Monkey", self.active_state_slot + 1),
-                    );
-                    return;
-                }
-                Err(LoadError::ViewStage) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        &fmt!(32, c"Cannot Load Savestate in View Stage"),
-                    );
-                    return;
-                }
-                Err(LoadError::PausedAndNonGameplaySubmode) => {
-                    cx.draw.notify(
-                        draw::RED,
-                        NotifyDuration::Short,
-                        &fmt!(32, c"Cannot Load Savestate, Please Unpause"),
-                    );
-                    return;
-                }
-            }
-
-            if !self.created_state_last_frame {
-                cx.draw.notify(
-                    draw::BLUE,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Slot %d Loaded", self.active_state_slot + 1),
-                );
-            }
+            self.load_slot(cx);
         } else {
             self.created_state_last_frame = false;
         }

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -1,6 +1,7 @@
 // TODO:
 // Don't spam notifications while holding a button
 // Add menu bind for clearing all savestates (and resets selected slot to 1)
+// Fix too long menu text
 
 use core::cell::Cell;
 
@@ -229,6 +230,15 @@ impl SaveStatesUi {
         );
     }
 
+    fn clear_all_slots(&mut self, cx: &mut Context) {
+        for state in &mut self.states {
+            state.clear(cx.lib_save_state);
+        }
+        self.active_state_slot = 0;
+        cx.draw
+            .notify(draw::BLUE, NotifyDuration::Short, "All Slots Cleared");
+    }
+
     fn load_slot(&mut self, cx: &mut Context) {
         let state = &mut self.states[self.active_state_slot];
         if let Err(code) = state.load(cx.lib_save_state, cx.timer) {
@@ -326,6 +336,7 @@ impl SaveStatesUi {
             return;
         }
         let clear_bind = pref.get_u8(U8Pref::SavestateClearBind);
+        let clear_all_bind = pref.get_u8(U8Pref::SavestateClearAllBind);
 
         // Must tick savestates every frame
         for state in &mut self.states {
@@ -359,6 +370,8 @@ impl SaveStatesUi {
             self.save_slot(cx);
         } else if cx.binds.bind_pressed(clear_bind, Prio::Low, cx.pad) {
             self.clear_slot(cx);
+        } else if cx.binds.bind_pressed(clear_all_bind, Prio::Low, cx.pad) {
+            self.clear_all_slots(cx);
         } else if cx
             .pad
             .button_down(mkb::PAD_BUTTON_Y as mkb::PadDigitalInput, Prio::Low)

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -1,7 +1,6 @@
 // TODO:
 // Don't spam notifications while holding a button
-// Add menu bind for clearing all savestates (and resets selected slot to 1)
-// Fix too long menu text
+// Fix default bind for clear all being "A"???
 
 use core::cell::Cell;
 

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -228,69 +228,64 @@ impl SaveStatesUi {
 
     fn load_slot(&mut self, cx: &mut Context) {
         let state = &mut self.states[self.active_state_slot];
-        match state.load(cx.lib_save_state, cx.timer) {
-            Ok(()) => {}
-            Err(LoadError::MainMode) => {
-                // Unreachable
-                panic!("Unreachable state in savestate load");
+        if let Err(code) = state.load(cx.lib_save_state, cx.timer) {
+            match code {
+                LoadError::MainMode => {
+                    // Unreachable
+                    panic!("Unreachable state in savestate load");
+                }
+                LoadError::SubMode => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Load Savestate Here",
+                    );
+                }
+                LoadError::TimeOver => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        "Cannot Load Savestate After Time Over",
+                    );
+                }
+                LoadError::Empty => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        &fmt!(32, c"Slot %d Empty", self.active_state_slot + 1),
+                    );
+                }
+                LoadError::WrongStage => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        &fmt!(32, c"Slot %d Wrong Stage", self.active_state_slot + 1),
+                    );
+                }
+                LoadError::WrongMonkey => {
+                    // Thank you StevenCW for finding this marvelous bug
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        &fmt!(32, c"Slot %d Wrong Monkey", self.active_state_slot + 1),
+                    );
+                }
+                LoadError::ViewStage => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        &fmt!(32, c"Cannot Load Savestate in View Stage"),
+                    );
+                }
+                LoadError::PausedAndNonGameplaySubmode => {
+                    cx.draw.notify(
+                        draw::RED,
+                        NotifyDuration::Short,
+                        &fmt!(32, c"Cannot Load Savestate, Please Unpause"),
+                    );
+                }
             }
-            Err(LoadError::SubMode) => {
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    "Cannot Load Savestate Here",
-                );
-                return;
-            }
-            Err(LoadError::TimeOver) => {
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    "Cannot Load Savestate After Time Over",
-                );
-                return;
-            }
-            Err(LoadError::Empty) => {
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Slot %d Empty", self.active_state_slot + 1),
-                );
-                return;
-            }
-            Err(LoadError::WrongStage) => {
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Slot %d Wrong Stage", self.active_state_slot + 1),
-                );
-                return;
-            }
-            Err(LoadError::WrongMonkey) => {
-                // Thank you StevenCW for finding this marvelous bug
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Slot %d Wrong Monkey", self.active_state_slot + 1),
-                );
-                return;
-            }
-            Err(LoadError::ViewStage) => {
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Cannot Load Savestate in View Stage"),
-                );
-                return;
-            }
-            Err(LoadError::PausedAndNonGameplaySubmode) => {
-                cx.draw.notify(
-                    draw::RED,
-                    NotifyDuration::Short,
-                    &fmt!(32, c"Cannot Load Savestate, Please Unpause"),
-                );
-                return;
-            }
+            return;
         }
 
         if !self.created_state_last_frame {

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -1,6 +1,4 @@
 // TODO:
-// Maybe try to see why size jumped up by 8kb?
-// Make sure stuff works with frame advance
 // Don't spam notifications while holding a button
 // Add menu bind for clearing all savestates (and resets selected slot to 1)
 
@@ -106,6 +104,11 @@ impl SaveStatesUi {
     }
 
     fn pick_save_slot(&self, cx: &mut Context) -> Option<usize> {
+        // Always write to current slot during frame advance
+        if self.frame_advance_mode {
+            return Some(self.active_state_slot);
+        }
+
         let save_to = SaveTo::try_from(cx.pref.get_u8(U8Pref::SavestateSaveTo)).unwrap();
         match save_to {
             SaveTo::Selected => Some(self.active_state_slot),

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -1,6 +1,3 @@
-// TODO:
-// Don't spam notifications while holding a button
-
 use core::cell::Cell;
 
 use critical_section::Mutex;

--- a/crates/smb2_practice_mod/src/systems/menu_defn.rs
+++ b/crates/smb2_practice_mod/src/systems/menu_defn.rs
@@ -491,7 +491,7 @@ static IW_MARK_HELP_WIDGETS: &[Widget] = &[
     },
     Widget::Separator {},
     Widget::Text {
-        label: "  Note that some visual-only mods, may also be",
+        label: "  Note that some visual-only mods may also be",
     },
     Widget::Text {
         label: "  disallowed for for IL leaderboard submissions.",
@@ -834,7 +834,7 @@ static HIDE_WIDGETS: &[Widget] = &[
 static SAVESTATE_SUBWIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Save To",
-        choices: &["Selected Slot", "Next Empty", "Next Empty, Then Oldest"],
+        choices: &["Selected Slot", "Next Empty Slot", "Empty, Then Oldest"],
         pref: U8Pref::SavestateSaveTo,
     },
     Widget::InputSelect {

--- a/crates/smb2_practice_mod/src/systems/menu_defn.rs
+++ b/crates/smb2_practice_mod/src/systems/menu_defn.rs
@@ -832,15 +832,16 @@ static HIDE_WIDGETS: &[Widget] = &[
 ];
 
 static SAVESTATE_SUBWIDGETS: &[Widget] = &[
+    Widget::Choose {
+        label: "Save To",
+        choices: &["Selected Slot", "Next Empty", "Next Empty, Then Oldest"],
+        pref: U8Pref::SavestateSaveTo,
+    },
     Widget::InputSelect {
         label: "Clear Savestate Bind",
         pref: U8Pref::SavestateClearBind,
         required_chord: false,
         can_unbind: true,
-    },
-    Widget::Checkbox {
-        label: "Prevent Overriding",
-        pref: BoolPref::SavestateDisableOverwrite,
     },
 ];
 

--- a/crates/smb2_practice_mod/src/systems/menu_defn.rs
+++ b/crates/smb2_practice_mod/src/systems/menu_defn.rs
@@ -843,6 +843,12 @@ static SAVESTATE_SUBWIDGETS: &[Widget] = &[
         required_chord: false,
         can_unbind: true,
     },
+    Widget::InputSelect {
+        label: "Clear All Bind",
+        pref: U8Pref::SavestateClearAllBind,
+        required_chord: false,
+        can_unbind: true,
+    },
 ];
 
 static SAVESTATE_WIDGETS: &[Widget] = &[

--- a/crates/smb2_practice_mod/src/systems/pref.rs
+++ b/crates/smb2_practice_mod/src/systems/pref.rs
@@ -161,7 +161,7 @@ pref_defn!(
     62 => PhysicsPreset: u8,
     // 63 belonged to physics friction which was only used in beta playtesting
     // 64 belonged to physics restitution which was only used in beta playtesting
-    65 => SavestateDisableOverwrite: bool,
+    // 65 belonged to SavestateDisableOverwrite
     66 => MenuBind: u8 = 64,
     67 => IlBattleReadyBind: u8 = 104,
     68 => FreecamToggleBind: u8 = 255,
@@ -182,6 +182,7 @@ pref_defn!(
     81 => MonkeyType: u8,
     82 => JumpProfile: u8,
     83 => CustomPhysicsDisp: bool = true,
+    84 => SavestateSaveTo: u8,
 );
 
 const PREF_BUF_SIZE: usize =

--- a/crates/smb2_practice_mod/src/systems/pref.rs
+++ b/crates/smb2_practice_mod/src/systems/pref.rs
@@ -183,6 +183,7 @@ pref_defn!(
     82 => JumpProfile: u8,
     83 => CustomPhysicsDisp: bool = true,
     84 => SavestateSaveTo: u8,
+    85 => SavestateClearAllBind: u8,
 );
 
 const PREF_BUF_SIZE: usize =

--- a/crates/smb2_practice_mod/src/systems/pref.rs
+++ b/crates/smb2_practice_mod/src/systems/pref.rs
@@ -183,7 +183,7 @@ pref_defn!(
     82 => JumpProfile: u8,
     83 => CustomPhysicsDisp: bool = true,
     84 => SavestateSaveTo: u8,
-    85 => SavestateClearAllBind: u8,
+    85 => SavestateClearAllBind: u8 = 255,
 );
 
 const PREF_BUF_SIZE: usize =

--- a/crates/smb2_practice_mod/src/utils/libsavestate.rs
+++ b/crates/smb2_practice_mod/src/utils/libsavestate.rs
@@ -28,7 +28,7 @@ static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
 });
 
 pub struct LibSaveState {
-    timestamp: u64,
+    timestamp: u32,
 }
 
 impl Default for LibSaveState {
@@ -77,7 +77,7 @@ pub struct SaveState {
     // None means empty savestate
     memstore: Option<memstore::Load>,
     // Timestamp of most recent action (load, save, clear, etc.)
-    timestamp: u64,
+    timestamp: u32,
     reload_state: bool,
 
     // TODO store in MemStore?
@@ -357,7 +357,7 @@ impl SaveState {
         self.timestamp = lib_save_state.timestamp;
     }
 
-    pub fn timestamp(&self) -> u64 {
+    pub fn timestamp(&self) -> u32 {
         self.timestamp
     }
 

--- a/crates/smb2_practice_mod/src/utils/libsavestate.rs
+++ b/crates/smb2_practice_mod/src/utils/libsavestate.rs
@@ -27,18 +27,24 @@ static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
     state_loaded_this_frame: Cell::new(false),
 });
 
-pub struct LibSaveState {}
+pub struct LibSaveState {
+    timestamp: u64,
+}
 
 impl Default for LibSaveState {
     fn default() -> Self {
         with_mutex(&GLOBALS, |cx| {
             cx.sound_req_id_hook.hook();
         });
-        Self {}
+        Self { timestamp: 0 }
     }
 }
 
 impl LibSaveState {
+    pub fn tick(&mut self) {
+        self.timestamp += 1;
+    }
+
     pub fn loaded_this_frame(&self) -> bool {
         with_mutex(&GLOBALS, |cx| cx.state_loaded_this_frame.get())
     }
@@ -70,6 +76,8 @@ pub enum LoadError {
 pub struct SaveState {
     // None means empty savestate
     memstore: Option<memstore::Load>,
+    // Timestamp of most recent action (load, save, clear, etc.)
+    timestamp: u64,
     reload_state: bool,
 
     // TODO store in MemStore?
@@ -80,16 +88,20 @@ pub struct SaveState {
 }
 
 impl SaveState {
-    pub fn tick(&mut self, timer: &mut Timer) {
+    pub fn tick(&mut self, lib_save_state: &LibSaveState, timer: &mut Timer) {
         with_mutex(&GLOBALS, |cx| {
             cx.state_loaded_this_frame.set(false);
         });
         if self.reload_state {
-            let _ = self.load(timer); // Ignore result, spooky!
+            let _ = self.load(lib_save_state, timer); // Ignore result, spooky!
         }
     }
 
-    pub fn save(&mut self, timer: &mut Timer) -> Result<(), SaveError> {
+    pub fn save(
+        &mut self,
+        lib_save_state: &LibSaveState,
+        timer: &mut Timer,
+    ) -> Result<(), SaveError> {
         unsafe {
             // Must be in main game
             if mkb::main_mode != mkb::MD_GAME {
@@ -130,6 +142,7 @@ impl SaveState {
             self.handle_pause_menu_save();
 
             self.memstore = Some(memstore::Load::from(save));
+            self.timestamp = lib_save_state.timestamp;
         }
 
         Ok(())
@@ -154,7 +167,11 @@ impl SaveState {
         }
     }
 
-    pub fn load(&mut self, timer: &mut Timer) -> Result<(), LoadError> {
+    pub fn load(
+        &mut self,
+        lib_save_state: &LibSaveState,
+        timer: &mut Timer,
+    ) -> Result<(), LoadError> {
         unsafe {
             // Must be in main game
             if mkb::main_mode != mkb::MD_GAME {
@@ -210,6 +227,7 @@ impl SaveState {
             with_mutex(&GLOBALS, |cx| {
                 cx.state_loaded_this_frame.set(true);
             });
+            self.timestamp = lib_save_state.timestamp;
         }
 
         Ok(())
@@ -334,8 +352,13 @@ impl SaveState {
         self.memstore.is_none()
     }
 
-    pub fn clear(&mut self) {
-        self.memstore = None
+    pub fn clear(&mut self, lib_save_state: &LibSaveState) {
+        self.memstore = None;
+        self.timestamp = lib_save_state.timestamp;
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
     }
 
     unsafe fn pass_over_regions(memstore: &mut MemStore, timer: &mut Timer) {

--- a/doc/size-optimization.md
+++ b/doc/size-optimization.md
@@ -1,0 +1,13 @@
+# Binary Size Optimization
+
+Here's some notes on keeping binary size low that I've picked up over time.
+
+First of all, I apply many of the tips from the [Rust binary size optimization guide](https://github.com/johnthagen/min-sized-rust). The most effective things have been:
+
+- Build with size-optimized LLVM profile
+- Abort on panic
+- Remove panic location info, formatting strings, and formatting code
+  - Removing panic strings and formatting code is behind a nightly-only flag. I try to avoid nightly features, but this one is pretty justified
+- Avoid core::fmt (although it's less safe, I wrap `mkb::sprintf`)
+
+I also recently discovered that avoiding 64-bit integer types saves around ~7kb! I guess for this 32-bit architecture it causes many software math functions to be pulled in.


### PR DESCRIPTION
- Add "save slot" behaviors:  save to selected slot (current), save to next empty slot, and save to next empty slot followed by oldest state.
- Add bind to clear all savestates
- Only display a notification a single time per savestate action (for ex: if new slot selected, don't hold the notification up while the C stick remains in the same position)
- Generally refactor savestates_ui a bit