### PR TITLE
Disable interrupts under Mutex

### DIFF
--- a/crates/smb2_practice_mod/Cargo.toml
+++ b/crates/smb2_practice_mod/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 arrayvec = { version = "0.7.6", default-features = false }
-critical-section = "1.1.3"
+critical-section = { version = "1.1.3", features = ["restore-state-u32"] }
 num_enum = { version = "0.7.3", default-features = false }
 once_cell = { version = "1.20.2", default-features = false, features = [
     "critical-section",

--- a/crates/smb2_practice_mod/src/mods/hide.rs
+++ b/crates/smb2_practice_mod/src/mods/hide.rs
@@ -1,124 +1,95 @@
-use critical_section::Mutex;
 use mkb::mkb;
 
 use crate::{
     app::with_app,
     hook,
     systems::pref::{BoolPref, Pref},
-    utils::{misc::with_mutex, patch},
+    utils::patch,
 };
 
-// BG
-struct Globals {
-    draw_bg_hook: DrawBgHook,
-    clear_hook: ClearHook,
-    draw_sprite_hook: DrawSpriteHook,
-    draw_minimap_hook: DrawMinimapHook,
-    draw_stage_hook: DrawStageHook,
-    draw_ball_hook: DrawBallHook,
-    draw_items_hook: DrawItemsHook,
-    draw_stobjs_hook: DrawStobjsHook,
-    draw_effects_hook: DrawEffectsHook,
-}
-
-static GLOBALS: Mutex<Globals> = Mutex::new(Globals {
-    draw_bg_hook: DrawBgHook::new(),
-    clear_hook: ClearHook::new(),
-    draw_sprite_hook: DrawSpriteHook::new(),
-    draw_minimap_hook: DrawMinimapHook::new(),
-    draw_stage_hook: DrawStageHook::new(),
-    draw_ball_hook: DrawBallHook::new(),
-    draw_items_hook: DrawItemsHook::new(),
-    draw_stobjs_hook: DrawStobjsHook::new(),
-    draw_effects_hook: DrawEffectsHook::new(),
-});
-
 hook!(DrawBgHook => (), mkb::g_draw_bg, || {
-    let should_hide = with_app(|cx| {
-        should_hide_bg(&cx.pref)
+    let (should_hide, hook) = with_app(|cx| {
+        (should_hide_bg(&cx.pref), cx.hide.draw_bg_hook.clone())
     });
-
-    with_mutex(&GLOBALS, |cx| {
-        if !should_hide {
-            cx.draw_bg_hook.call();
-        }
-    });
+    if !should_hide {
+        hook.call();
+    }
 });
 
 hook!(ClearHook => (), mkb::g_set_clear_color, || {
-    let should_hide = with_app(|cx| {
-        should_hide_bg(&cx.pref)
+    let (should_hide, hook) = with_app(|cx| {
+        (should_hide_bg(&cx.pref), cx.hide.clear_hook.clone())
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        if should_hide {
-            unsafe {
-                let backup_color = mkb::g_some_theme_color;
-                let backup_override_r = mkb::g_override_clear_r;
-                let backup_override_g = mkb::g_override_clear_g;
-                let backup_override_b = mkb::g_override_clear_b;
+    if should_hide {
+        unsafe {
+            let backup_color = mkb::g_some_theme_color;
+            let backup_override_r = mkb::g_override_clear_r;
+            let backup_override_g = mkb::g_override_clear_g;
+            let backup_override_b = mkb::g_override_clear_b;
 
-                mkb::g_some_theme_color = mkb::GXColor {r: 0, g: 0, b: 0, a: 0xff};
-                mkb::g_override_clear_r = 0;
-                mkb::g_override_clear_g = 0;
-                mkb::g_override_clear_b = 0;
+            mkb::g_some_theme_color = mkb::GXColor {r: 0, g: 0, b: 0, a: 0xff};
+            mkb::g_override_clear_r = 0;
+            mkb::g_override_clear_g = 0;
+            mkb::g_override_clear_b = 0;
 
-                cx.clear_hook.call();
+            hook.call();
 
-                mkb::g_some_theme_color = backup_color;
-                mkb::g_override_clear_r = backup_override_r;
-                mkb::g_override_clear_g = backup_override_g;
-                mkb::g_override_clear_b = backup_override_b;
-            }
-        } else {
-            cx.clear_hook.call();
+            mkb::g_some_theme_color = backup_color;
+            mkb::g_override_clear_r = backup_override_r;
+            mkb::g_override_clear_g = backup_override_g;
+            mkb::g_override_clear_b = backup_override_b;
         }
-    });
+    } else {
+        hook.call();
+    }
 });
 
 // HUD
 hook!(DrawSpriteHook, sprite: *mut mkb::Sprite => (), mkb::draw_sprite, |sprite| {
-    let (hide_hud, freecam_hide) = with_app(|cx| {
-        (cx.pref.get_bool(BoolPref::HideHud), cx.freecam.should_hide_hud(&cx.pref))
+    let (hide_hud, freecam_hide, hook) = with_app(|cx| {
+        (
+            cx.pref.get_bool(BoolPref::HideHud),
+            cx.freecam.should_hide_hud(&cx.pref),
+            cx.hide.draw_sprite_hook.clone(),
+        )
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        unsafe {
-            let correct_mode = mkb::main_mode == mkb::MD_GAME;
-            let disp_func = (*sprite).disp_func;
-            let is_pausemenu_sprite = disp_func == Some(mkb::sprite_pausemenu_disp);
-            if !((hide_hud || freecam_hide) && correct_mode && !is_pausemenu_sprite) {
-                cx.draw_sprite_hook.call(sprite);
-            }
+    unsafe {
+        let correct_mode = mkb::main_mode == mkb::MD_GAME;
+        let disp_func = (*sprite).disp_func;
+        let is_pausemenu_sprite = disp_func == Some(mkb::sprite_pausemenu_disp);
+        if !((hide_hud || freecam_hide) && correct_mode && !is_pausemenu_sprite) {
+            hook.call(sprite);
         }
-    });
+    }
 });
 
 hook!(DrawMinimapHook => (), mkb::g_draw_minimap, || {
-    let (hide_hud, freecam_hide) = with_app(|cx| {
+    let (hide_hud, freecam_hide, hook) = with_app(|cx| {
         let pref = &cx.pref;
         let freecam = &cx.freecam;
-        (pref.get_bool(BoolPref::HideHud), freecam.should_hide_hud(pref))
+        (
+            pref.get_bool(BoolPref::HideHud),
+            freecam.should_hide_hud(pref),
+            cx.hide.draw_minimap_hook.clone(),
+        )
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        if !(hide_hud || freecam_hide) {
-            cx.draw_minimap_hook.call();
-        }
-    });
+    if !(hide_hud || freecam_hide) {
+        hook.call();
+    }
 });
 
 // Stage
 hook!(DrawStageHook => (), mkb::g_draw_stage, || {
-    let should_hide = with_app(|cx| {
-        cx.pref.get_bool(BoolPref::HideStage)
+    let (should_hide, hook) = with_app(|cx| {
+        (cx.pref.get_bool(BoolPref::HideStage), cx.hide.draw_stage_hook.clone())
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        if !should_hide {
-            cx.draw_stage_hook.call();
-        }
-    });
+    if !should_hide {
+        hook.call();
+    }
 });
 
 // Ball
@@ -127,50 +98,42 @@ hook!(DrawBallHook => (), mkb::g_draw_ball_and_ape, || {
         cx.pref.get_bool(BoolPref::HideBall)
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        if !should_hide {
-            cx.draw_ball_hook.call();
-        }
-    });
+    if !should_hide {
+        with_app(|cx| cx.hide.draw_ball_hook.clone()).call();
+    }
 });
 
 // Items
 hook!(DrawItemsHook => (), mkb::draw_items, || {
-    let should_hide = with_app(|cx| {
-        cx.pref.get_bool(BoolPref::HideItems)
+    let (should_hide, hook) = with_app(|cx| {
+        (cx.pref.get_bool(BoolPref::HideItems), cx.hide.draw_items_hook.clone())
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        if !should_hide {
-            cx.draw_items_hook.call();
-        }
-    });
+    if !should_hide {
+        hook.call();
+    }
 });
 
 // Stage objects
 hook!(DrawStobjsHook => (), mkb::g_draw_stobjs, || {
-    let should_hide = with_app(|cx| {
-        cx.pref.get_bool(BoolPref::HideStobjs)
+    let (should_hide, hook) = with_app(|cx| {
+        (cx.pref.get_bool(BoolPref::HideStobjs), cx.hide.draw_stobjs_hook.clone())
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        if !should_hide {
-            cx.draw_stobjs_hook.call();
-        }
-    });
+    if !should_hide {
+        hook.call();
+    }
 });
 
 // Effects
 hook!(DrawEffectsHook => (), mkb::g_draw_effects, || {
-    let should_hide = with_app(|cx| {
-        cx.pref.get_bool(BoolPref::HideEffects)
+    let (should_hide, hook) = with_app(|cx| {
+        (cx.pref.get_bool(BoolPref::HideEffects), cx.hide.draw_effects_hook.clone())
     });
 
-    with_mutex(&GLOBALS, |cx| {
-        if !should_hide {
-            cx.draw_effects_hook.call();
-        }
-    });
+    if !should_hide {
+        hook.call();
+    }
 });
 
 fn should_hide_bg(pref: &Pref) -> bool {
@@ -198,25 +161,53 @@ unsafe extern "C" fn nl2ngc_set_fog_color_hook(r: u8, g: u8, b: u8) {
     }
 }
 
-pub struct Hide {}
+pub struct Hide {
+    draw_bg_hook: DrawBgHook,
+    clear_hook: ClearHook,
+    draw_sprite_hook: DrawSpriteHook,
+    draw_minimap_hook: DrawMinimapHook,
+    draw_stage_hook: DrawStageHook,
+    draw_ball_hook: DrawBallHook,
+    draw_items_hook: DrawItemsHook,
+    draw_stobjs_hook: DrawStobjsHook,
+    draw_effects_hook: DrawEffectsHook,
+}
 
 impl Default for Hide {
     fn default() -> Self {
-        with_mutex(&GLOBALS, |cx| {
-            unsafe {
-                patch::write_branch_bl(0x80352e58 as *mut _, avdisp_set_fog_color_hook as *mut _);
-                patch::write_branch_bl(0x80352eac as *mut _, nl2ngc_set_fog_color_hook as *mut _);
-            }
-            cx.draw_bg_hook.hook();
-            cx.clear_hook.hook();
-            cx.draw_sprite_hook.hook();
-            cx.draw_minimap_hook.hook();
-            cx.draw_stage_hook.hook();
-            cx.draw_ball_hook.hook();
-            cx.draw_items_hook.hook();
-            cx.draw_stobjs_hook.hook();
-            cx.draw_effects_hook.hook();
-        });
-        Self {}
+        let draw_bg_hook = DrawBgHook::new();
+        draw_bg_hook.hook();
+        let clear_hook = ClearHook::new();
+        clear_hook.hook();
+        let draw_sprite_hook = DrawSpriteHook::new();
+        draw_sprite_hook.hook();
+        let draw_minimap_hook = DrawMinimapHook::new();
+        draw_minimap_hook.hook();
+        let draw_stage_hook = DrawStageHook::new();
+        draw_stage_hook.hook();
+        let draw_ball_hook = DrawBallHook::new();
+        draw_ball_hook.hook();
+        let draw_items_hook = DrawItemsHook::new();
+        draw_items_hook.hook();
+        let draw_stobjs_hook = DrawStobjsHook::new();
+        draw_stobjs_hook.hook();
+        let draw_effects_hook = DrawEffectsHook::new();
+        draw_effects_hook.hook();
+
+        unsafe {
+            patch::write_branch_bl(0x80352e58 as *mut _, avdisp_set_fog_color_hook as *mut _);
+            patch::write_branch_bl(0x80352eac as *mut _, nl2ngc_set_fog_color_hook as *mut _);
+        }
+        Self {
+            draw_bg_hook,
+            clear_hook,
+            draw_sprite_hook,
+            draw_minimap_hook,
+            draw_stage_hook,
+            draw_ball_hook,
+            draw_items_hook,
+            draw_stobjs_hook,
+            draw_effects_hook,
+        }
     }
 }

--- a/crates/smb2_practice_mod/src/systems/cardio.rs
+++ b/crates/smb2_practice_mod/src/systems/cardio.rs
@@ -90,81 +90,91 @@ impl CardIo {
         }
     }
 
+    unsafe fn read_file_internal(&mut self, file_name: &str) -> Result<Vec<u8>, CARDResult> {
+        let _fake_gamecode = FakeGamecode::new();
+        let mut res;
+
+        // Probe card
+        loop {
+            res = to_card_result(mkb::CARDProbeEx(0, null_mut(), null_mut()));
+            if res != CARDResult::Busy {
+                break;
+            }
+        }
+        if res != CARDResult::Ready {
+            return Err(res);
+        }
+
+        // Mount card
+        mkb::CARDMountAsync(
+            0,
+            self.card_work_area.as_mut_ptr() as *mut c_void,
+            null_mut(),
+            null_mut(),
+        );
+        loop {
+            res = to_card_result(mkb::CARDGetResultCode(0));
+            if res != CARDResult::Busy {
+                break;
+            }
+        }
+        if res != CARDResult::Ready {
+            return Err(res);
+        }
+        // Open file
+        res = to_card_result(mkb::CARDOpen(
+            0,
+            cstr!(16, file_name),
+            &mut self.card_file_info,
+        ));
+        if res != CARDResult::Ready {
+            mkb::CARDUnmount(0);
+            return Err(res);
+        }
+
+        // Get file size
+        let mut stat = mkb::CARDStat::default();
+        res = to_card_result(mkb::CARDGetStatus(0, self.card_file_info.fileNo, &mut stat));
+        if res != CARDResult::Ready {
+            mkb::CARDUnmount(0);
+            return Err(res);
+        }
+
+        let buf_size = math::round_up_pow2(stat.length as usize, CARD_READ_SIZE as usize);
+        let mut buf = vec![0u8; buf_size];
+
+        mkb::CARDReadAsync(
+            &mut self.card_file_info as *mut _,
+            buf.as_mut_ptr() as *mut _,
+            buf_size as c_long,
+            0,
+            null_mut(),
+        );
+        loop {
+            res = to_card_result(mkb::CARDGetResultCode(0));
+            if res != CARDResult::Busy {
+                break;
+            }
+        }
+        if res != CARDResult::Ready {
+            mkb::CARDUnmount(0);
+            return Err(res);
+        }
+
+        mkb::CARDUnmount(0);
+        Ok(buf)
+    }
+
     // Synchronous at the moment. Also, do not call while write_file() is running!
     pub fn read_file(&mut self, file_name: &str) -> Result<Vec<u8>, CARDResult> {
         unsafe {
-            let _fake_gamecode = FakeGamecode::new();
-            let mut res;
-
-            // Probe card
-            loop {
-                res = to_card_result(mkb::CARDProbeEx(0, null_mut(), null_mut()));
-                if res != CARDResult::Busy {
-                    break;
-                }
-            }
-            if res != CARDResult::Ready {
-                return Err(res);
-            }
-
-            // Mount card
-            mkb::CARDMountAsync(
-                0,
-                self.card_work_area.as_mut_ptr() as *mut c_void,
-                null_mut(),
-                null_mut(),
-            );
-            loop {
-                res = to_card_result(mkb::CARDGetResultCode(0));
-                if res != CARDResult::Busy {
-                    break;
-                }
-            }
-            if res != CARDResult::Ready {
-                return Err(res);
-            }
-            // Open file
-            res = to_card_result(mkb::CARDOpen(
-                0,
-                cstr!(16, file_name),
-                &mut self.card_file_info,
-            ));
-            if res != CARDResult::Ready {
-                mkb::CARDUnmount(0);
-                return Err(res);
-            }
-
-            // Get file size
-            let mut stat = mkb::CARDStat::default();
-            res = to_card_result(mkb::CARDGetStatus(0, self.card_file_info.fileNo, &mut stat));
-            if res != CARDResult::Ready {
-                mkb::CARDUnmount(0);
-                return Err(res);
-            }
-
-            let buf_size = math::round_up_pow2(stat.length as usize, CARD_READ_SIZE as usize);
-            let mut buf = vec![0u8; buf_size];
-
-            mkb::CARDReadAsync(
-                &mut self.card_file_info as *mut _,
-                buf.as_mut_ptr() as *mut _,
-                buf_size as c_long,
-                0,
-                null_mut(),
-            );
-            loop {
-                res = to_card_result(mkb::CARDGetResultCode(0));
-                if res != CARDResult::Busy {
-                    break;
-                }
-            }
-            if res != CARDResult::Ready {
-                mkb::CARDUnmount(0);
-                return Err(res);
-            }
-
-            mkb::CARDUnmount(0);
-            Ok(buf)
+            // HACK: re-enable interrupts during reading so we don't block forever. We wouldn't need to if
+            // we read async like we do for writing, but if e.g. SMB2WorkshopMod also did this on startup
+            // we'd have to coordinate non-overlapping reads of stuff at startup.
+            let interrupts = mkb::OSEnableInterrupts();
+            let result = self.read_file_internal(file_name);
+            mkb::OSRestoreInterrupts(interrupts);
+            result
         }
     }
 

--- a/crates/smb2_practice_mod/src/utils/hook.rs
+++ b/crates/smb2_practice_mod/src/utils/hook.rs
@@ -3,9 +3,7 @@ macro_rules! hook {
     ($name:ident $(, $argname:ident: $arg:ty)* => $ret:ty, $their_func:expr, $our_func:expr) => {
         pub struct $name {
             instrs: [core::cell::Cell<usize>; 2],
-            // chained_func: core::cell::Cell<Option<extern "C" fn($($arg,)*) -> $ret>>,
             their_func: unsafe extern "C" fn($($arg,)*) -> $ret,
-            // our_func_c: extern "C" fn($($arg,)*) -> $ret,
             jumpback_addr: core::cell::Cell<usize>,
         }
 
@@ -19,15 +17,12 @@ macro_rules! hook {
             const fn new() -> Self {
                 Self {
                     instrs: [core::cell::Cell::new(0), core::cell::Cell::new(0)],
-                    // chained_func: core::cell::Cell::new(None),
                     their_func: $their_func,
                     jumpback_addr: core::cell::Cell::new(0),
-                    // our_func_c: Self::c_hook,
                 }
             }
 
             pub fn hook(&self) {
-                $crate::log!(c"Start of hook()");
                 unsafe {
                     let hook_info = $crate::patch::hook_function_part1(
                         self.their_func as *mut usize,
@@ -35,38 +30,24 @@ macro_rules! hook {
                     );
                     self.instrs[0].set(hook_info.first_instr);
                     self.jumpback_addr.set(hook_info.jumpback_addr as usize);
-                    // let chained_func = core::mem::transmute::<
-                    //     *const core::ffi::c_void,
-                    //     extern "C" fn($($arg,)*) -> $ret
-                    // >(chained_func_addr);
-                    // self.chained_func.set(Some(chained_func));
                 }
-                $crate::log!(c"End of hook()");
             }
 
             // We sometimes want to replace the hooked function entirely and never call the original
             #[allow(dead_code)]
             pub fn call(&self $(, $argname: $arg)*) -> $ret {
-                $crate::log!(c"%s: Start of call()", $crate::cstr!(64, core::stringify!($name)));
-                let ret = unsafe {
+                unsafe {
                     $crate::patch::hook_function_part2(
                         &self.instrs,
                         self.jumpback_addr.get() as *const usize,
                     );
-                    $crate::log!(c"instrs: 0x%08X, 0x%08X", self.instrs[0].get(), self.instrs[1].get());
                     let chained_func =
                         core::mem::transmute::<
                             *const core::ffi::c_void,
                             extern "C" fn($($arg,)*) -> $ret
                         >(self.instrs.as_ptr() as *const core::ffi::c_void);
-                    $crate::log!(c"chained func addr: 0x%08X", chained_func);
-                    $crate::log!(c"%s: before chained func()", $crate::cstr!(64, core::stringify!($name)));
-                    let ret = chained_func($($argname,)*);
-                    $crate::log!(c"%s: after chained func()", $crate::cstr!(64, core::stringify!($name)));
-                    ret
-                };
-                $crate::log!(c"End of call()");
-                ret
+                    chained_func($($argname,)*)
+                }
             }
 
             extern "C" fn c_hook($($argname: $arg, )*) -> $ret {

--- a/crates/smb2_practice_mod/src/utils/hook.rs
+++ b/crates/smb2_practice_mod/src/utils/hook.rs
@@ -35,7 +35,9 @@ macro_rules! hook {
 
             // We sometimes want to replace the hooked function entirely and never call the original
             #[allow(dead_code)]
-            pub fn call(&self $(, $argname: $arg)*) -> $ret {
+            pub fn call(self $(, $argname: $arg)*) -> $ret {
+                // We take self as a compile-time reminder that hooks must be cloned and moved out
+                // of Mutex scope before being called
                 unsafe {
                     $crate::patch::hook_function_part2(
                         &self.instrs,

--- a/crates/smb2_practice_mod/src/utils/hook.rs
+++ b/crates/smb2_practice_mod/src/utils/hook.rs
@@ -1,9 +1,9 @@
 #[macro_export]
 macro_rules! hook {
     ($name:ident $(, $argname:ident: $arg:ty)* => $ret:ty, $their_func:expr, $our_func:expr) => {
+        #[derive(Clone)]
         pub struct $name {
             instrs: [core::cell::Cell<usize>; 2],
-            their_func: unsafe extern "C" fn($($arg,)*) -> $ret,
             jumpback_addr: core::cell::Cell<usize>,
         }
 
@@ -17,15 +17,15 @@ macro_rules! hook {
             const fn new() -> Self {
                 Self {
                     instrs: [core::cell::Cell::new(0), core::cell::Cell::new(0)],
-                    their_func: $their_func,
                     jumpback_addr: core::cell::Cell::new(0),
                 }
             }
 
             pub fn hook(&self) {
+                let their_func = $their_func;
                 unsafe {
                     let hook_info = $crate::patch::hook_function_part1(
-                        self.their_func as *mut usize,
+                        their_func as *mut usize,
                         Self::c_hook as *const usize,
                     );
                     self.instrs[0].set(hook_info.first_instr);

--- a/crates/smb2_practice_mod/src/utils/hook.rs
+++ b/crates/smb2_practice_mod/src/utils/hook.rs
@@ -3,9 +3,10 @@ macro_rules! hook {
     ($name:ident $(, $argname:ident: $arg:ty)* => $ret:ty, $their_func:expr, $our_func:expr) => {
         pub struct $name {
             instrs: [core::cell::Cell<usize>; 2],
-            chained_func: core::cell::Cell<Option<extern "C" fn($($arg,)*) -> $ret>>,
+            // chained_func: core::cell::Cell<Option<extern "C" fn($($arg,)*) -> $ret>>,
             their_func: unsafe extern "C" fn($($arg,)*) -> $ret,
-            our_func_c: extern "C" fn($($arg,)*) -> $ret,
+            // our_func_c: extern "C" fn($($arg,)*) -> $ret,
+            jumpback_addr: core::cell::Cell<usize>,
         }
 
         impl Default for $name {
@@ -18,33 +19,54 @@ macro_rules! hook {
             const fn new() -> Self {
                 Self {
                     instrs: [core::cell::Cell::new(0), core::cell::Cell::new(0)],
-                    chained_func: core::cell::Cell::new(None),
+                    // chained_func: core::cell::Cell::new(None),
                     their_func: $their_func,
-                    our_func_c: Self::c_hook,
+                    jumpback_addr: core::cell::Cell::new(0),
+                    // our_func_c: Self::c_hook,
                 }
             }
 
             pub fn hook(&self) {
+                $crate::log!(c"Start of hook()");
                 unsafe {
-                    let mut chained_func_addr = core::ptr::null();
-                    $crate::patch::hook_function(
+                    let hook_info = $crate::patch::hook_function_part1(
                         self.their_func as *mut usize,
-                        self.our_func_c as *mut usize,
-                        &self.instrs,
-                        &mut chained_func_addr,
+                        Self::c_hook as *const usize,
                     );
-                    let chained_func = core::mem::transmute::<
-                        *const core::ffi::c_void,
-                        extern "C" fn($($arg,)*) -> $ret
-                    >(chained_func_addr);
-                    self.chained_func.set(Some(chained_func));
+                    self.instrs[0].set(hook_info.first_instr);
+                    self.jumpback_addr.set(hook_info.jumpback_addr as usize);
+                    // let chained_func = core::mem::transmute::<
+                    //     *const core::ffi::c_void,
+                    //     extern "C" fn($($arg,)*) -> $ret
+                    // >(chained_func_addr);
+                    // self.chained_func.set(Some(chained_func));
                 }
+                $crate::log!(c"End of hook()");
             }
 
             // We sometimes want to replace the hooked function entirely and never call the original
             #[allow(dead_code)]
             pub fn call(&self $(, $argname: $arg)*) -> $ret {
-                (self.chained_func.get().unwrap())($($argname,)*)
+                $crate::log!(c"%s: Start of call()", $crate::cstr!(64, core::stringify!($name)));
+                let ret = unsafe {
+                    $crate::patch::hook_function_part2(
+                        &self.instrs,
+                        self.jumpback_addr.get() as *const usize,
+                    );
+                    $crate::log!(c"instrs: 0x%08X, 0x%08X", self.instrs[0].get(), self.instrs[1].get());
+                    let chained_func =
+                        core::mem::transmute::<
+                            *const core::ffi::c_void,
+                            extern "C" fn($($arg,)*) -> $ret
+                        >(self.instrs.as_ptr() as *const core::ffi::c_void);
+                    $crate::log!(c"chained func addr: 0x%08X", chained_func);
+                    $crate::log!(c"%s: before chained func()", $crate::cstr!(64, core::stringify!($name)));
+                    let ret = chained_func($($argname,)*);
+                    $crate::log!(c"%s: after chained func()", $crate::cstr!(64, core::stringify!($name)));
+                    ret
+                };
+                $crate::log!(c"End of call()");
+                ret
             }
 
             extern "C" fn c_hook($($argname: $arg, )*) -> $ret {

--- a/crates/smb2_practice_mod/src/utils/libsavestate.rs
+++ b/crates/smb2_practice_mod/src/utils/libsavestate.rs
@@ -10,11 +10,13 @@ use crate::{hook, mods::timer::Timer};
 
 // Re-entrant hook, cannot use app state
 hook!(SoundReqIdHook, sfx_idx: u32 => (), mkb::call_SoundReqID_arg_0, |sfx_idx| {
-    with_mutex(&GLOBALS, |cx| {
-        if !cx.state_loaded_this_frame.get() {
-            cx.sound_req_id_hook.call(sfx_idx);
-        }
-    });
+    let (loaded_this_frame, hook) = with_mutex(&GLOBALS, |cx| (
+        cx.state_loaded_this_frame.get(),
+        cx.sound_req_id_hook.clone()
+    ));
+    if !loaded_this_frame {
+        hook.call(sfx_idx);
+    }
 });
 
 struct Globals {

--- a/crates/smb2_practice_mod/src/utils/patch.rs
+++ b/crates/smb2_practice_mod/src/utils/patch.rs
@@ -71,12 +71,12 @@ pub unsafe fn write_nop(ptr: *mut usize) -> usize {
     write_word(ptr, 0x60000000)
 }
 
-pub unsafe fn hook_function(
-    func: *mut usize,
-    dest: *mut usize,
-    tramp_instrs: &[Cell<usize>; 2],
-    tramp_dest: &mut *const c_void,
-) {
+pub struct HookInfo {
+    pub first_instr: usize,
+    pub jumpback_addr: *const c_void,
+}
+
+pub unsafe fn hook_function_part1(func: *mut usize, dest: *const usize) -> HookInfo {
     if (*func & ppc::B_OPCODE_MASK) == ppc::B_OPCODE {
         // Func has been hooked already, chain the hooks
 
@@ -89,27 +89,50 @@ pub unsafe fn hook_function(
         let old_dest = func as usize + old_dest_offset;
 
         // Hook to our new func instead
-        write_branch(func, dest as *mut _);
+        write_branch(func, dest as *const _);
 
-        // Use the old hooked func as the trampoline dest
-        *tramp_dest = old_dest as *const c_void;
+        let mut first_instr = 0;
+        write_nop(&raw mut first_instr);
+
+        HookInfo {
+            first_instr,
+            jumpback_addr: old_dest as *const c_void,
+        }
     } else {
-        // Func has not been hooked yet
-        // Original instruction
-        tramp_instrs[0].set(*func);
-        clear_dc_ic_cache(tramp_instrs.as_ptr() as *mut _, size_of::<usize>());
-
-        // Branch to original func past hook
-        write_branch(
-            &tramp_instrs[1],
-            transmute::<*const usize, *const c_void>(func.add(1) as *const _),
-        );
-
-        // The function pointer to run as the original function is the addr of the trampoline
-        // instructions array
-        *tramp_dest = transmute::<*const Cell<usize>, *const c_void>(tramp_instrs.as_ptr());
+        let first_instr = *func;
 
         // Write actual hook
-        write_branch(func, dest as *mut _);
+        write_branch(func, dest as *const _);
+
+        HookInfo {
+            first_instr,
+            jumpback_addr: func.add(1) as *const c_void,
+        }
+
+        // Func has not been hooked yet
+        // Original instruction
+        // tramp_instrs[0].set(*func);
+        // clear_dc_ic_cache(tramp_instrs.as_ptr() as *mut _, size_of::<usize>());
+
+        // // Branch to original func past hook
+        // write_branch(
+        //     &tramp_instrs[1],
+        //     transmute::<*const usize, *const c_void>(func.add(1) as *const _),
+        // );
+
+        // // The function pointer to run as the original function is the addr of the trampoline
+        // // instructions array
+        // *tramp_dest = transmute::<*const Cell<usize>, *const c_void>(tramp_instrs.as_ptr());
     }
+}
+
+pub unsafe fn hook_function_part2(instrs: &[Cell<usize>; 2], jumpback_addr: *const usize) {
+    // Update branch instruction to reflect hook's new position in memory
+    write_branch(
+        &instrs[1],
+        transmute::<*const usize, *const c_void>(jumpback_addr),
+    );
+    // Flush/Invalidate caches for both instructions, as this function is meant to be called after
+    // cloning a hook
+    clear_dc_ic_cache(instrs.as_ptr() as *const _, size_of::<[Cell<usize>; 2]>());
 }

--- a/crates/smb2_practice_mod/src/utils/patch.rs
+++ b/crates/smb2_practice_mod/src/utils/patch.rs
@@ -108,21 +108,6 @@ pub unsafe fn hook_function_part1(func: *mut usize, dest: *const usize) -> HookI
             first_instr,
             jumpback_addr: func.add(1) as *const c_void,
         }
-
-        // Func has not been hooked yet
-        // Original instruction
-        // tramp_instrs[0].set(*func);
-        // clear_dc_ic_cache(tramp_instrs.as_ptr() as *mut _, size_of::<usize>());
-
-        // // Branch to original func past hook
-        // write_branch(
-        //     &tramp_instrs[1],
-        //     transmute::<*const usize, *const c_void>(func.add(1) as *const _),
-        // );
-
-        // // The function pointer to run as the original function is the addr of the trampoline
-        // // instructions array
-        // *tramp_dest = transmute::<*const Cell<usize>, *const c_void>(tramp_instrs.as_ptr());
     }
 }
 


### PR DESCRIPTION
Disabling interrupts while our code is running may help prevent the random crashes I've been experiencing. This required a bit of a refactor because we now want to call hooks without holding a Mutex, which means hooks must be cloneable/moveable.

Unfortunately this PR seems to grow the binary by 10KB, which is much more than I'd expect. The simpler but mostly adequate approach of just disabling interrupts inside `with_app()` probably costs much less space - it'd be nice to know why this approach costs so much though.