### PR TITLE
U8Pref -> I16Pref

### DIFF
--- a/crates/smb2_practice_mod/src/mods/camera.rs
+++ b/crates/smb2_practice_mod/src/mods/camera.rs
@@ -2,12 +2,12 @@ use mkb::mkb;
 use num_enum::TryFromPrimitive;
 
 use crate::patch;
-use crate::systems::pref::{self, U8Pref};
+use crate::systems::pref::{self, I16Pref};
 use crate::systems::pref::{FromPref, Pref};
 use crate::utils::ppc;
 
 #[derive(TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 enum CameraType {
     Default = 0,
     ForceSMB2 = 1,
@@ -19,11 +19,11 @@ pub struct Camera {}
 
 impl Camera {
     unsafe fn tick_unsafe(&self, pref: &Pref) {
-        let value = CameraType::from_pref(U8Pref::Camera, pref);
+        let value = CameraType::from_pref(I16Pref::Camera, pref);
 
         match value {
             CameraType::Default => {
-                if pref.did_change(pref::U8Pref::Camera) {
+                if pref.did_change(pref::I16Pref::Camera) {
                     // restore cam to smb2 once (so toggle still works)
                     if mkb::cameras[0].mode == 0x1 {
                         mkb::cameras[0].mode = 0x4c;

--- a/crates/smb2_practice_mod/src/mods/cmseg.rs
+++ b/crates/smb2_practice_mod/src/mods/cmseg.rs
@@ -9,7 +9,7 @@ use crate::{
     hook,
     systems::{
         draw,
-        pref::{BoolPref, FromPref, Pref, U8Pref},
+        pref::{BoolPref, FromPref, I16Pref, Pref},
     },
     utils::{misc::with_mutex, timerdisp},
 };
@@ -63,7 +63,7 @@ pub enum Seg {
 }
 
 #[derive(Copy, Clone, TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 enum Chara {
     AiAi,
     MeeMee,
@@ -212,7 +212,7 @@ impl CmSeg {
 
     unsafe fn state_seg_active(&mut self, pref: &Pref) {
         if mkb::sub_mode_request == mkb::SMD_GAME_READY_INIT {
-            let ch = Chara::from_pref(U8Pref::CmChara, pref);
+            let ch = Chara::from_pref(I16Pref::CmChara, pref);
             mkb::active_monkey_id[0] = match ch {
                 Chara::Random => APE_CHARAS[mkb::rand() as usize % 4],
                 _ => APE_CHARAS[ch as usize],

--- a/crates/smb2_practice_mod/src/mods/fallout.rs
+++ b/crates/smb2_practice_mod/src/mods/fallout.rs
@@ -6,14 +6,14 @@ use mkb::mkb;
 use num_enum::TryFromPrimitive;
 
 use crate::{
-    systems::pref::{BoolPref, Pref, U8Pref},
+    systems::pref::{BoolPref, I16Pref, Pref},
     utils::{math::fabs, patch},
 };
 
 use super::freecam::Freecam;
 
 #[derive(PartialEq, Eq, TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 enum FalloutPlaneType {
     Normal,
     Disabled,
@@ -21,7 +21,7 @@ enum FalloutPlaneType {
 }
 
 #[derive(PartialEq, Eq, TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 enum TimerType {
     Default,
     FreezeInstantly,
@@ -89,7 +89,7 @@ impl Default for Fallout {
 
 impl Fallout {
     pub fn freeze_timer(&mut self, pref: &Pref, freecam: &Freecam) {
-        let mut timer_type = TimerType::from_pref(U8Pref::TimerType, pref);
+        let mut timer_type = TimerType::from_pref(I16Pref::TimerType, pref);
         if freecam.should_freeze_timer(pref) {
             timer_type = TimerType::FreezeInstantly;
             self.toggled_freecam = true;
@@ -98,7 +98,7 @@ impl Fallout {
         unsafe {
             match timer_type {
                 TimerType::Default => {
-                    if pref.did_change(U8Pref::TimerType) || self.toggled_freecam {
+                    if pref.did_change(I16Pref::TimerType) || self.toggled_freecam {
                         // time over at 0 frames
                         patch::write_word(0x80297548 as *mut usize, self.timeover_condition);
                         // add -1 to timer each frame
@@ -156,7 +156,7 @@ impl Fallout {
         unsafe {
             let below_fallout = (*ball).pos.y < (*(*mkb::stagedef).fallout).y;
             let volumes_disabled = pref.get(BoolPref::DisableFalloutVolumes);
-            let plane_type = FalloutPlaneType::from_pref(U8Pref::FalloutPlaneType, pref);
+            let plane_type = FalloutPlaneType::from_pref(I16Pref::FalloutPlaneType, pref);
 
             match plane_type {
                 FalloutPlaneType::Normal => {

--- a/crates/smb2_practice_mod/src/mods/ilbattle.rs
+++ b/crates/smb2_practice_mod/src/mods/ilbattle.rs
@@ -8,7 +8,7 @@ use crate::{
         binds::Binds,
         draw,
         pad::{Pad, Prio},
-        pref::{BoolPref, FromPref, Pref, U8Pref},
+        pref::{BoolPref, FromPref, I16Pref, Pref},
     },
 };
 
@@ -33,7 +33,7 @@ enum IlBattleState {
 }
 
 #[derive(Clone, Copy, TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 enum IlBattleLength {
     FiveMinutes = 0,
     SevenMinutes = 1,
@@ -227,7 +227,7 @@ impl IlBattle {
             }
 
             // breakdown
-            let breakdown_value = cx.pref.get(U8Pref::IlBattleBreakdown);
+            let breakdown_value = cx.pref.get(I16Pref::IlBattleBreakdown);
             if breakdown_value == 1 {
                 // minimal
                 current_y += CHEIGHT;
@@ -314,7 +314,7 @@ impl IlBattle {
     }
 
     fn clear_display(&mut self, cx: &Context) {
-        let battle_len = IlBattleLength::from_pref(U8Pref::IlBattleLength, cx.pref);
+        let battle_len = IlBattleLength::from_pref(I16Pref::IlBattleLength, cx.pref);
 
         self.battle_frames = 0;
         self.best_frames = 0;
@@ -354,7 +354,7 @@ impl IlBattle {
                 self.accepted_retry = true;
             }
 
-            let battle_length = IlBattleLength::from_pref(U8Pref::IlBattleLength, cx.pref);
+            let battle_length = IlBattleLength::from_pref(I16Pref::IlBattleLength, cx.pref);
             if matches!(battle_length, IlBattleLength::Endless) {
                 // timer is endless
                 self.battle_frames += 1;
@@ -532,9 +532,11 @@ impl IlBattle {
 
             // Resets battles when Dpad Down is pressed
             if mkb::main_mode == mkb::MD_GAME
-                && cx
-                    .binds
-                    .bind_pressed(cx.pref.get(U8Pref::IlBattleReadyBind), Prio::Low, cx.pad)
+                && cx.binds.bind_pressed(
+                    cx.pref.get(I16Pref::IlBattleReadyBind) as u8,
+                    Prio::Low,
+                    cx.pad,
+                )
             {
                 self.new_battle(cx);
             }
@@ -567,9 +569,9 @@ impl IlBattle {
                 if unsafe { mkb::main_mode } != mkb::MD_GAME {
                     return;
                 }
-                let input = cx.pref.get(U8Pref::IlBattleReadyBind);
+                let input = cx.pref.get(I16Pref::IlBattleReadyBind);
                 let mut buf = ArrayString::<32>::new();
-                cx.binds.get_bind_str(input, &mut buf);
+                cx.binds.get_bind_str(input as u8, &mut buf);
                 draw::debug_text(X - 12 * CWIDTH, Y, draw::LIGHT_PURPLE, "NOT READY");
                 draw::debug_text(
                     X - 12 * CWIDTH,

--- a/crates/smb2_practice_mod/src/mods/inputdisp.rs
+++ b/crates/smb2_practice_mod/src/mods/inputdisp.rs
@@ -11,13 +11,13 @@ use crate::systems::pref::FromPref;
 use crate::systems::{
     draw,
     pad::{self, Pad, Prio, StickState},
-    pref::{BoolPref, Pref, U8Pref},
+    pref::{BoolPref, I16Pref, Pref},
 };
 
 use super::{ballcolor::BallColor, freecam::Freecam};
 
 #[derive(Copy, Clone, PartialEq, Eq, TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 pub enum InputDispColorType {
     Default = 0,
     Rgb = 1,
@@ -26,7 +26,7 @@ pub enum InputDispColorType {
 }
 
 #[derive(TryFromPrimitive, PartialEq, Eq)]
-#[repr(u8)]
+#[repr(i16)]
 enum Location {
     Right,
     Center,
@@ -159,7 +159,7 @@ impl InputDisplay {
 
     pub fn tick(&mut self, pref: &Pref) {
         self.rainbow = (self.rainbow + 3) % 1080;
-        let location = Location::from_pref(U8Pref::InputDispLocation, pref);
+        let location = Location::from_pref(I16Pref::InputDispLocation, pref);
         self.set_sprite_visible(
             !pref.get(BoolPref::InputDisp)
                 || (location == Location::Center && !pref.get(BoolPref::InputDispRawStickInputs)),
@@ -217,14 +217,14 @@ impl InputDisplay {
     ];
 
     fn get_color(&self, cx: &Context) -> mkb::GXColor {
-        match InputDispColorType::from_pref(U8Pref::InputDispColorType, cx.pref) {
+        match InputDispColorType::from_pref(I16Pref::InputDispColorType, cx.pref) {
             InputDispColorType::Default => {
-                Self::COLOR_MAP[cx.pref.get(U8Pref::InputDispColor) as usize]
+                Self::COLOR_MAP[cx.pref.get(I16Pref::InputDispColor) as usize]
             }
             InputDispColorType::Rgb => mkb::GXColor {
-                r: cx.pref.get(U8Pref::InputDispRed),
-                g: cx.pref.get(U8Pref::InputDispGreen),
-                b: cx.pref.get(U8Pref::InputDispBlue),
+                r: cx.pref.get(I16Pref::InputDispRed) as u8,
+                g: cx.pref.get(I16Pref::InputDispGreen) as u8,
+                b: cx.pref.get(I16Pref::InputDispBlue) as u8,
                 a: 0xff,
             },
             InputDispColorType::Rainbow => draw::num_to_rainbow(self.rainbow),
@@ -391,7 +391,7 @@ impl InputDisplay {
         }
 
         let center = Vec2d {
-            x: match Location::from_pref(U8Pref::InputDispLocation, cx.pref) {
+            x: match Location::from_pref(I16Pref::InputDispLocation, cx.pref) {
                 Location::Right => 540.0,
                 Location::Center => 390.0,
             },
@@ -445,7 +445,7 @@ impl InputDisplay {
             return;
         }
 
-        let center = match Location::from_pref(U8Pref::InputDispLocation, cx.pref) {
+        let center = match Location::from_pref(I16Pref::InputDispLocation, cx.pref) {
             Location::Center => Vec2d { x: 430.0, y: 60.0 },
             Location::Right => Vec2d { x: 534.0, y: 60.0 },
         };

--- a/crates/smb2_practice_mod/src/mods/jump.rs
+++ b/crates/smb2_practice_mod/src/mods/jump.rs
@@ -5,7 +5,7 @@ use mkb::mkb;
 use crate::{
     systems::{
         pad::{Button, Pad, Prio},
-        pref::{BoolPref, FromPref, Pref, U8Pref},
+        pref::{BoolPref, FromPref, I16Pref, Pref},
     },
     utils::{math::fabs, patch},
 };
@@ -13,7 +13,7 @@ use crate::{
 use super::physics::PhysicsPreset;
 
 #[derive(Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 enum MaxJumpCount {
     One = 0,
     Two = 1,
@@ -88,7 +88,7 @@ impl Jump {
     fn enable(&mut self, pref: &mut Pref) {
         self.patch_minimap(pref);
         if pref.get(BoolPref::JumpChangePhysics) {
-            pref.set(U8Pref::PhysicsPreset, PhysicsPreset::JumpPhysics as u8);
+            pref.set(I16Pref::PhysicsPreset, PhysicsPreset::JumpPhysics as i16);
             pref.save();
         }
         self.reset();
@@ -97,7 +97,7 @@ impl Jump {
     fn disable(&mut self, pref: &mut Pref) {
         self.restore_minimap();
         if pref.get(BoolPref::JumpChangePhysics) {
-            pref.set(U8Pref::PhysicsPreset, PhysicsPreset::Default as u8);
+            pref.set(I16Pref::PhysicsPreset, PhysicsPreset::Default as i16);
             pref.save();
         }
     }
@@ -154,7 +154,7 @@ impl Jump {
             if ground_touched && valid_location {
                 self.ticks_since_ground = 0;
 
-                let count = MaxJumpCount::from_pref(U8Pref::JumpCount, pref);
+                let count = MaxJumpCount::from_pref(I16Pref::JumpCount, pref);
                 if count == MaxJumpCount::Two {
                     self.aerial_jumps = 1;
                 } else {
@@ -170,7 +170,7 @@ impl Jump {
                 ground_touched && self.ticks_since_jump_input < EARLY_BUFFER_LENGTH && a_down;
             let coyote_late = self.ticks_since_ground < LATE_BUFFER_LENGTH && a_pressed;
             // check extra jump count
-            let max_jump = MaxJumpCount::from_pref(U8Pref::JumpCount, pref);
+            let max_jump = MaxJumpCount::from_pref(I16Pref::JumpCount, pref);
             let aerial_jumped =
                 (self.aerial_jumps > 0 || max_jump == MaxJumpCount::Infinite) && a_pressed;
             let start_jump = mkb::sub_mode == mkb::SMD_GAME_PLAY_INIT
@@ -301,9 +301,9 @@ impl Jump {
         if enabled {
             if pref.did_change(BoolPref::JumpChangePhysics) {
                 if pref.get(BoolPref::JumpChangePhysics) {
-                    pref.set(U8Pref::PhysicsPreset, PhysicsPreset::JumpPhysics as u8);
+                    pref.set(I16Pref::PhysicsPreset, PhysicsPreset::JumpPhysics as i16);
                 } else {
-                    pref.set(U8Pref::PhysicsPreset, PhysicsPreset::Default as u8);
+                    pref.set(I16Pref::PhysicsPreset, PhysicsPreset::Default as i16);
                 }
                 pref.save();
             }
@@ -315,7 +315,7 @@ impl Jump {
             }
             Self::toggle_minimap(pad);
 
-            let new_jump_profile = pref.get(U8Pref::JumpProfile) == 0;
+            let new_jump_profile = pref.get(I16Pref::JumpProfile) == 0;
 
             if new_jump_profile {
                 self.jumping(pref, pad);

--- a/crates/smb2_practice_mod/src/mods/physics.rs
+++ b/crates/smb2_practice_mod/src/mods/physics.rs
@@ -4,7 +4,7 @@ use num_enum::TryFromPrimitive;
 
 use crate::systems::{
     draw,
-    pref::{BoolPref, FromPref, Pref, U8Pref},
+    pref::{BoolPref, FromPref, I16Pref, Pref},
 };
 
 use super::freecam::Freecam;
@@ -15,7 +15,7 @@ struct Context<'a> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 pub enum PhysicsPreset {
     Default,
     LightBall,
@@ -45,7 +45,7 @@ impl Default for Physics {
 
 impl Physics {
     pub fn using_custom_physics(&self, pref: &Pref) -> bool {
-        let preset: PhysicsPreset = PhysicsPreset::from_pref(U8Pref::PhysicsPreset, pref);
+        let preset: PhysicsPreset = PhysicsPreset::from_pref(I16Pref::PhysicsPreset, pref);
         preset != PhysicsPreset::Default
     }
 
@@ -57,7 +57,7 @@ impl Physics {
             mkb::balls[mkb::curr_player_idx as usize].restitution = self.orig_restitution;
 
             // update physics depending on preset
-            let preset: PhysicsPreset = PhysicsPreset::from_pref(U8Pref::PhysicsPreset, cx.pref);
+            let preset: PhysicsPreset = PhysicsPreset::from_pref(I16Pref::PhysicsPreset, cx.pref);
             match preset {
                 PhysicsPreset::Default => {}
                 PhysicsPreset::LightBall => {

--- a/crates/smb2_practice_mod/src/mods/savestates_ui.rs
+++ b/crates/smb2_practice_mod/src/mods/savestates_ui.rs
@@ -10,7 +10,7 @@ use crate::{
         binds::Binds,
         draw::{self, Draw, NotifyDuration},
         pad::{Analog, Button, Dir, Pad, Prio},
-        pref::{BoolPref, FromPref, Pref, U8Pref},
+        pref::{BoolPref, FromPref, I16Pref, Pref},
     },
     utils::{
         libsavestate::{LibSaveState, LoadError, SaveError, SaveState},
@@ -55,7 +55,7 @@ struct Context<'a> {
 }
 
 #[derive(TryFromPrimitive)]
-#[repr(u8)]
+#[repr(i16)]
 enum SaveTo {
     Selected,
     NextEmpty,
@@ -113,7 +113,7 @@ impl SaveStatesUi {
             return Some(self.active_state_slot);
         }
 
-        let save_to = SaveTo::from_pref(U8Pref::SavestateSaveTo, cx.pref);
+        let save_to = SaveTo::from_pref(I16Pref::SavestateSaveTo, cx.pref);
         match save_to {
             SaveTo::Selected => Some(self.active_state_slot),
             SaveTo::NextEmpty => self.find_next_empty(),
@@ -340,8 +340,8 @@ impl SaveStatesUi {
         if !savestates_enabled(cx.pref) {
             return;
         }
-        let clear_bind = pref.get(U8Pref::SavestateClearBind);
-        let clear_all_bind = pref.get(U8Pref::SavestateClearAllBind);
+        let clear_bind = pref.get(I16Pref::SavestateClearBind);
+        let clear_all_bind = pref.get(I16Pref::SavestateClearAllBind);
 
         // Must tick savestates every frame
         for state in &mut self.states {
@@ -372,9 +372,12 @@ impl SaveStatesUi {
 
         if cx.pad.button_pressed(Button::X, Prio::Low) {
             self.save_slot(cx);
-        } else if cx.binds.bind_pressed(clear_bind, Prio::Low, cx.pad) {
+        } else if cx.binds.bind_pressed(clear_bind as u8, Prio::Low, cx.pad) {
             self.clear_slot(cx);
-        } else if cx.binds.bind_pressed(clear_all_bind, Prio::Low, cx.pad) {
+        } else if cx
+            .binds
+            .bind_pressed(clear_all_bind as u8, Prio::Low, cx.pad)
+        {
             self.clear_all_slots(cx);
         } else if load_reason != LoadReason::NoLoad {
             self.load_slot(load_reason, cx);

--- a/crates/smb2_practice_mod/src/mods/stage_edits.rs
+++ b/crates/smb2_practice_mod/src/mods/stage_edits.rs
@@ -6,7 +6,7 @@ use num_enum::TryFromPrimitive;
 use crate::{
     app::with_app,
     hook,
-    systems::pref::{FromPref, Pref, U8Pref},
+    systems::pref::{FromPref, I16Pref, Pref},
     utils::misc::with_mutex,
 };
 
@@ -20,7 +20,7 @@ hook!(LoadStagedefHook, stage_id: u32 => (), mkb::load_stagedef, |stage_id| {
 });
 
 #[derive(Clone, Copy, PartialEq, Eq, TryFromPrimitive, Default)]
-#[repr(u8)]
+#[repr(i16)]
 pub enum ActiveMode {
     #[default]
     None = 0,
@@ -147,7 +147,7 @@ impl StageEdits {
     }
 
     fn on_load_stagedef(&mut self, pref: &Pref) {
-        let next_mode = ActiveMode::from_pref(U8Pref::StageEditVariant, pref);
+        let next_mode = ActiveMode::from_pref(I16Pref::StageEditVariant, pref);
         self.current_mode = next_mode;
         unsafe {
             self.set_mode(self.current_mode);
@@ -155,7 +155,7 @@ impl StageEdits {
     }
 
     pub fn on_game_ready_init(&mut self, pref: &Pref) {
-        let next_mode = ActiveMode::from_pref(U8Pref::StageEditVariant, pref);
+        let next_mode = ActiveMode::from_pref(I16Pref::StageEditVariant, pref);
         if self.current_mode != next_mode {
             unsafe {
                 self.undo_mode(self.current_mode);

--- a/crates/smb2_practice_mod/src/mods/validate.rs
+++ b/crates/smb2_practice_mod/src/mods/validate.rs
@@ -11,7 +11,7 @@ use crate::{
     systems::{
         menu_impl::MenuImpl,
         pad::{Pad, Prio},
-        pref::{BoolPref, Pref, U8Pref},
+        pref::{BoolPref, I16Pref, Pref},
     },
     utils::libsavestate::LibSaveState,
 };
@@ -74,11 +74,11 @@ const INVALID_BOOL_PREFS: &[BoolPref] = &[
     BoolPref::DebugMode,
 ];
 
-const INVALID_U8_PREFS: &[U8Pref] = &[
-    U8Pref::PhysicsPreset,
-    U8Pref::TimerType,
-    U8Pref::FalloutPlaneType,
-    U8Pref::StageEditVariant,
+const INVALID_U8_PREFS: &[I16Pref] = &[
+    I16Pref::PhysicsPreset,
+    I16Pref::TimerType,
+    I16Pref::FalloutPlaneType,
+    I16Pref::StageEditVariant,
 ];
 
 impl Validate {

--- a/crates/smb2_practice_mod/src/systems/binds.rs
+++ b/crates/smb2_practice_mod/src/systems/binds.rs
@@ -1,4 +1,3 @@
-
 use arrayvec::ArrayString;
 
 use super::pad::{Button, Pad, Prio};

--- a/crates/smb2_practice_mod/src/systems/menu_defn.rs
+++ b/crates/smb2_practice_mod/src/systems/menu_defn.rs
@@ -8,7 +8,7 @@ use crate::mods::stage_edits::StageEdits;
 use crate::mods::unlock::Unlock;
 use crate::mods::validate::Validate;
 use crate::mods::{ballcolor, freecam};
-use crate::systems::pref::{BoolPref, U8Pref};
+use crate::systems::pref::{BoolPref, I16Pref};
 use crate::utils::version;
 use crate::{cstr_buf, fmt_buf};
 
@@ -71,7 +71,7 @@ pub enum Widget {
     Choose {
         label: &'static str,
         choices: &'static [&'static str],
-        pref: U8Pref,
+        pref: I16Pref,
     },
     Button {
         label: &'static str,
@@ -80,13 +80,13 @@ pub enum Widget {
     },
     IntEdit {
         label: &'static str,
-        pref: U8Pref,
-        min: u8,
-        max: u8,
+        pref: I16Pref,
+        min: i16,
+        max: i16,
     },
     InputSelect {
         label: &'static str,
-        pref: U8Pref,
+        pref: I16Pref,
         required_chord: bool,
         can_unbind: bool,
     },
@@ -98,9 +98,9 @@ pub enum Widget {
         draw: fn(&mut MenuContext),
     },
     RgbPreview {
-        r_pref: U8Pref,
-        g_pref: U8Pref,
-        b_pref: U8Pref,
+        r_pref: I16Pref,
+        g_pref: I16Pref,
+        b_pref: I16Pref,
     },
     Separator {},
 }
@@ -112,30 +112,30 @@ static INPUT_PRESET: &[Widget] = &[Widget::Choose {
     choices: &[
         "Purple", "Red", "Orange", "Yellow", "Green", "Blue", "Pink", "Black",
     ],
-    pref: U8Pref::InputDispColor,
+    pref: I16Pref::InputDispColor,
 }];
 
 static INPUT_HEX: &[Widget] = &[
     Widget::RgbPreview {
-        r_pref: U8Pref::InputDispRed,
-        g_pref: U8Pref::InputDispGreen,
-        b_pref: U8Pref::InputDispBlue,
+        r_pref: I16Pref::InputDispRed,
+        g_pref: I16Pref::InputDispGreen,
+        b_pref: I16Pref::InputDispBlue,
     },
     Widget::IntEdit {
         label: "Red Value",
-        pref: U8Pref::InputDispRed,
+        pref: I16Pref::InputDispRed,
         min: ballcolor::COLOR_MIN,
         max: ballcolor::COLOR_MAX,
     },
     Widget::IntEdit {
         label: "Green Value",
-        pref: U8Pref::InputDispGreen,
+        pref: I16Pref::InputDispGreen,
         min: ballcolor::COLOR_MIN,
         max: ballcolor::COLOR_MAX,
     },
     Widget::IntEdit {
         label: "Blue Value",
-        pref: U8Pref::InputDispBlue,
+        pref: I16Pref::InputDispBlue,
         min: ballcolor::COLOR_MIN,
         max: ballcolor::COLOR_MAX,
     },
@@ -145,7 +145,7 @@ static INPUTDISP_SUBWIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Location",
         choices: &["Right", "Center"],
-        pref: U8Pref::InputDispLocation,
+        pref: I16Pref::InputDispLocation,
     },
     Widget::Checkbox {
         label: "Notch Indicators",
@@ -158,15 +158,15 @@ static INPUTDISP_SUBWIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Color Type",
         choices: &["Preset", "RGB Selector", "Rainbow", "Match Ball"],
-        pref: U8Pref::InputDispColorType,
+        pref: I16Pref::InputDispColorType,
     },
     Widget::HideableGroup {
         widgets: INPUT_PRESET,
-        show_if: |cx| cx.pref.get(U8Pref::InputDispColorType) == 0,
+        show_if: |cx| cx.pref.get(I16Pref::InputDispColorType) == 0,
     },
     Widget::HideableGroup {
         widgets: INPUT_HEX,
-        show_if: |cx| cx.pref.get(U8Pref::InputDispColorType) == 1,
+        show_if: |cx| cx.pref.get(I16Pref::InputDispColorType) == 1,
     },
 ];
 
@@ -188,36 +188,36 @@ static BALL_COLORS: &[&str] = &[
 static PRESET_WIDGETS: &[Widget] = &[Widget::Choose {
     label: "Preset Color",
     choices: BALL_COLORS,
-    pref: U8Pref::BallColor,
+    pref: I16Pref::BallColor,
 }];
 
 static PRESET_APE_WIDGETS: &[Widget] = &[Widget::Choose {
     label: "Preset Color",
     choices: BALL_COLORS,
-    pref: U8Pref::ApeColor,
+    pref: I16Pref::ApeColor,
 }];
 
 static HEX_WIDGETS: &[Widget] = &[
     Widget::RgbPreview {
-        r_pref: U8Pref::BallRed,
-        g_pref: U8Pref::BallGreen,
-        b_pref: U8Pref::BallBlue,
+        r_pref: I16Pref::BallRed,
+        g_pref: I16Pref::BallGreen,
+        b_pref: I16Pref::BallBlue,
     },
     Widget::IntEdit {
         label: "Red Value",
-        pref: U8Pref::BallRed,
+        pref: I16Pref::BallRed,
         min: ballcolor::COLOR_MIN,
         max: ballcolor::COLOR_MAX,
     },
     Widget::IntEdit {
         label: "Green Value",
-        pref: U8Pref::BallGreen,
+        pref: I16Pref::BallGreen,
         min: ballcolor::COLOR_MIN,
         max: ballcolor::COLOR_MAX,
     },
     Widget::IntEdit {
         label: "Blue Value",
-        pref: U8Pref::BallBlue,
+        pref: I16Pref::BallBlue,
         min: ballcolor::COLOR_MIN,
         max: ballcolor::COLOR_MAX,
     },
@@ -232,15 +232,15 @@ static BALL_COLOR_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Ball Color Type",
         choices: &["Preset", "RGB Selector", "Rainbow", "Random"],
-        pref: U8Pref::BallColorType,
+        pref: I16Pref::BallColorType,
     },
     Widget::HideableGroup {
         widgets: PRESET_WIDGETS,
-        show_if: |cx| cx.pref.get(U8Pref::BallColorType) == 0,
+        show_if: |cx| cx.pref.get(I16Pref::BallColorType) == 0,
     },
     Widget::HideableGroup {
         widgets: HEX_WIDGETS,
-        show_if: |cx| cx.pref.get(U8Pref::BallColorType) == 1,
+        show_if: |cx| cx.pref.get(I16Pref::BallColorType) == 1,
     },
     Widget::Separator {},
     Widget::Header {
@@ -249,36 +249,36 @@ static BALL_COLOR_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Clothing Color Type",
         choices: &["Preset", "Random"],
-        pref: U8Pref::ApeColorType,
+        pref: I16Pref::ApeColorType,
     },
     Widget::HideableGroup {
         widgets: PRESET_APE_WIDGETS,
-        show_if: |cx| cx.pref.get(U8Pref::ApeColorType) == 0,
+        show_if: |cx| cx.pref.get(I16Pref::ApeColorType) == 0,
     },
     Widget::Separator {},
     Widget::Header { label: "Monkey" },
     Widget::Choose {
         label: "Monkey Type",
         choices: MONKEY_TYPES,
-        pref: U8Pref::MonkeyType,
+        pref: I16Pref::MonkeyType,
     },
 ];
 
 static IL_BATTLE_SCORE_WIDGETS: &[Widget] = &[Widget::Choose {
     label: "Score Breakdown",
     choices: &["Off", "Minimal", "Full"],
-    pref: U8Pref::IlBattleBreakdown,
+    pref: I16Pref::IlBattleBreakdown,
 }];
 
 static IL_BATTLE_SUBWIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Battle Length",
         choices: &["5 min", "7 min", "10 min", "Endless"],
-        pref: U8Pref::IlBattleLength,
+        pref: I16Pref::IlBattleLength,
     },
     Widget::InputSelect {
         label: "Ready Bind",
-        pref: U8Pref::IlBattleReadyBind,
+        pref: I16Pref::IlBattleReadyBind,
         required_chord: false,
         can_unbind: true,
     },
@@ -763,7 +763,7 @@ static CM_SEG_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Character",
         choices: CHARA_CHOICES,
-        pref: U8Pref::CmChara,
+        pref: I16Pref::CmChara,
     },
     Widget::Separator {},
     Widget::Text {
@@ -881,7 +881,7 @@ static FREECAM_WIDGETS: &[Widget] = &[
     },
     Widget::InputSelect {
         label: "Toggle Bind",
-        pref: U8Pref::FreecamToggleBind,
+        pref: I16Pref::FreecamToggleBind,
         required_chord: false,
         can_unbind: true,
     },
@@ -899,7 +899,7 @@ static FREECAM_WIDGETS: &[Widget] = &[
     },
     Widget::IntEdit {
         label: "Turbo Speed Factor",
-        pref: U8Pref::FreecamSpeedMult,
+        pref: I16Pref::FreecamSpeedMult,
         min: freecam::TURBO_SPEED_MIN,
         max: freecam::TURBO_SPEED_MAX,
     },
@@ -957,17 +957,17 @@ static SAVESTATE_SUBWIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Save To",
         choices: &["Selected Slot", "Next Empty Slot", "Empty, Then Oldest"],
-        pref: U8Pref::SavestateSaveTo,
+        pref: I16Pref::SavestateSaveTo,
     },
     Widget::InputSelect {
         label: "Clear Savestate Bind",
-        pref: U8Pref::SavestateClearBind,
+        pref: I16Pref::SavestateClearBind,
         required_chord: false,
         can_unbind: true,
     },
     Widget::InputSelect {
         label: "Clear All Bind",
-        pref: U8Pref::SavestateClearAllBind,
+        pref: I16Pref::SavestateClearAllBind,
         required_chord: false,
         can_unbind: true,
     },
@@ -1132,47 +1132,47 @@ static PHYSICS_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Physics Presets",
         choices: PHYSICS_PRESETS,
-        pref: U8Pref::PhysicsPreset,
+        pref: I16Pref::PhysicsPreset,
     },
     Widget::HideableGroup {
         widgets: &[Widget::Text {
             label: "  Weight: 1.00 -> 0.95",
         }],
-        show_if: |cx| cx.pref.get(U8Pref::PhysicsPreset) == 1,
+        show_if: |cx| cx.pref.get(I16Pref::PhysicsPreset) == 1,
     },
     Widget::HideableGroup {
         widgets: &[Widget::Text {
             label: "  Friction: 0.010 -> 0.000",
         }],
-        show_if: |cx| cx.pref.get(U8Pref::PhysicsPreset) == 2,
+        show_if: |cx| cx.pref.get(I16Pref::PhysicsPreset) == 2,
     },
     Widget::HideableGroup {
         widgets: &[Widget::Text {
             label: "  Weight: 1.00 -> 1.05",
         }],
-        show_if: |cx| cx.pref.get(U8Pref::PhysicsPreset) == 3,
+        show_if: |cx| cx.pref.get(I16Pref::PhysicsPreset) == 3,
     },
     Widget::HideableGroup {
         widgets: &[Widget::Text {
             label: "  Restitution: 0.50 -> 1.20",
         }],
-        show_if: |cx| cx.pref.get(U8Pref::PhysicsPreset) == 4,
+        show_if: |cx| cx.pref.get(I16Pref::PhysicsPreset) == 4,
     },
     Widget::HideableGroup {
         widgets: &[Widget::Text {
             label: "  Restitution: 0.50 -> 0.01",
         }],
-        show_if: |cx| cx.pref.get(U8Pref::PhysicsPreset) == 5,
+        show_if: |cx| cx.pref.get(I16Pref::PhysicsPreset) == 5,
     },
     Widget::HideableGroup {
         widgets: &[Widget::Text {
             label: "  Friction: 0.010 -> 0.020",
         }],
-        show_if: |cx| cx.pref.get(U8Pref::PhysicsPreset) == 6,
+        show_if: |cx| cx.pref.get(I16Pref::PhysicsPreset) == 6,
     },
     Widget::HideableGroup {
         widgets: JUMP_PHYSICS,
-        show_if: |cx| cx.pref.get(U8Pref::PhysicsPreset) == 7,
+        show_if: |cx| cx.pref.get(I16Pref::PhysicsPreset) == 7,
     },
     Widget::Checkbox {
         label: "Display Physics Text",
@@ -1192,11 +1192,11 @@ static STAGE_EDIT_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Stage Edit Mode",
         choices: STAGE_EDIT_VARIANTS,
-        pref: U8Pref::StageEditVariant,
+        pref: I16Pref::StageEditVariant,
     },
     Widget::HideableGroup {
         widgets: REVERSE_GOAL_WIDGETS,
-        show_if: |cx| cx.pref.get(U8Pref::StageEditVariant) == 3,
+        show_if: |cx| cx.pref.get(I16Pref::StageEditVariant) == 3,
     },
     Widget::Text {
         label: "  Stage Edits are activated on retry",
@@ -1238,7 +1238,7 @@ static JUMP_STANDARD_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Jump Count",
         choices: JUMP_COUNTS,
-        pref: U8Pref::JumpCount,
+        pref: I16Pref::JumpCount,
     },
 ];
 
@@ -1248,15 +1248,15 @@ static JUMP_PROFILES_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Jump Profile",
         choices: JUMP_PROFILES,
-        pref: U8Pref::JumpProfile,
+        pref: I16Pref::JumpProfile,
     },
     Widget::HideableGroup {
         widgets: JUMP_STANDARD_WIDGETS,
-        show_if: |cx| cx.pref.get(U8Pref::JumpProfile) == 0,
+        show_if: |cx| cx.pref.get(I16Pref::JumpProfile) == 0,
     },
     Widget::HideableGroup {
         widgets: JUMP_CLASSIC_WIDGETS,
-        show_if: |cx| cx.pref.get(U8Pref::JumpProfile) == 1,
+        show_if: |cx| cx.pref.get(I16Pref::JumpProfile) == 1,
     },
 ];
 
@@ -1289,7 +1289,7 @@ static VARIANT_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Camera Type",
         choices: CAMERA_OPTIONS,
-        pref: U8Pref::Camera,
+        pref: I16Pref::Camera,
     },
     Widget::Checkbox {
         label: "D-Pad Controls",
@@ -1304,12 +1304,12 @@ static VARIANT_WIDGETS: &[Widget] = &[
     Widget::Choose {
         label: "Timer Type",
         choices: TIMER_TYPES,
-        pref: U8Pref::TimerType,
+        pref: I16Pref::TimerType,
     },
     Widget::Choose {
         label: "Fallout Plane Type",
         choices: FALLOUT_PLANE_TYPE,
-        pref: U8Pref::FalloutPlaneType,
+        pref: I16Pref::FalloutPlaneType,
     },
     Widget::Checkbox {
         label: "Disable Fallout Volume",
@@ -1355,7 +1355,7 @@ static RESET_PREFS_WIDGETS: &[Widget] = &[
 static PRACMOD_SETTINGS_WIDGETS: &[Widget] = &[
     Widget::InputSelect {
         label: "Menu Bind",
-        pref: U8Pref::MenuBind,
+        pref: I16Pref::MenuBind,
         required_chord: true,
         can_unbind: false,
     },

--- a/crates/smb2_practice_mod/src/systems/pref.rs
+++ b/crates/smb2_practice_mod/src/systems/pref.rs
@@ -15,15 +15,15 @@ use super::{
 macro_rules! pref_defn {
     ($( // Line
         $id:literal => $pref_name:ident:
-            $(u8 $(= $u8_default:literal)?)?
+            $(i16 $(= $i16_default:literal)?)?
             $(bool $(= $bool_default:literal)?)?
     ),+ $(,)?) => {
         const BOOL_PREF_COUNT: usize = [$(
             $(swallow!((), ($($bool_default)?)),)?
         )+].len();
 
-        const U8_PREF_COUNT: usize = [$(
-            $(swallow!((), ($($u8_default)?)),)?
+        const I16_PREF_COUNT: usize = [$(
+            $(swallow!((), ($($i16_default)?)),)?
         )+].len();
 
         const ALL_PREF_IDS: &[PrefId] = &[
@@ -36,9 +36,9 @@ macro_rules! pref_defn {
             )+
         ];
 
-        const DEFAULT_U8S: &[DefaultU8] = &[
+        const DEFAULT_I16S: &[DefaultI16] = &[
             $( // Line
-                $($(DefaultU8 { id: U8Pref::$pref_name, value: $u8_default},)?)?
+                $($(DefaultI16 { id: I16Pref::$pref_name, value: $i16_default},)?)?
             )+
         ];
 
@@ -52,11 +52,11 @@ macro_rules! pref_defn {
 
         #[derive(Clone, Copy)]
         #[repr(u16)]
-        pub enum U8Pref {
+        pub enum I16Pref {
             $( // Line
-                // Making a doc attr is a way to use u8_default to select the right repetition, while
+                // Making a doc attr is a way to use i16_default to select the right repetition, while
                 // producing a valid syntax element
-                $(#[doc = core::concat!("default=", core::stringify!($($u8_default)?))] $pref_name,)?
+                $(#[doc = core::concat!("default=", core::stringify!($($i16_default)?))] $pref_name,)?
             )+
         }
 
@@ -78,10 +78,10 @@ macro_rules! pref_defn {
                 }
             }
 
-            fn pref_id_to_u8_pref(id: PrefId) -> Option<U8Pref> {
+            fn pref_id_to_i16_pref(id: PrefId) -> Option<I16Pref> {
                 match id {
                     $( // Line
-                        $(PrefId::$pref_name => swallow!((Some(U8Pref::$pref_name)), ($($u8_default)?)),)?
+                        $(PrefId::$pref_name => swallow!((Some(I16Pref::$pref_name)), ($($i16_default)?)),)?
                     )*
                     _ => None,
                 }
@@ -99,10 +99,10 @@ macro_rules! swallow {
 pref_defn!(
     1 => Savestates: bool = true,
     2 => InputDisp: bool,
-    3 => InputDispLocation: u8 = 1,
+    3 => InputDispLocation: i16 = 1,
     4 => TimerShowRTA: bool,
-    5 => CmChara: u8,
-    6 => InputDispColor: u8,
+    5 => CmChara: i16,
+    6 => InputDispColor: i16,
     7 => InputDispNotchIndicators: bool = true,
     8 => IwTimer: bool = true,
     9 => CmTimer: bool = true,
@@ -115,12 +115,12 @@ pref_defn!(
     16 => MuteTimerDing: bool,
     17 => InputDispRawStickInputs: bool,
     18 => Freecam: bool,
-    19 => BallColor: u8,
-    20 => ApeColor: u8,
+    19 => BallColor: i16,
+    20 => ApeColor: i16,
     21 => Marathon: bool,
     // Do not reuse 22, it belonged to old Moon Gravity BoolPref
     23 => IlBattleDisplay: bool,
-    24 => IlBattleLength: u8,
+    24 => IlBattleLength: i16,
     // Do not reuse 25, it belonged to old IL Battle Score Breakdown BoolPref
     26 => IlMarkPractice: bool = true,
     27 => IlMarkStory: bool,
@@ -131,7 +131,7 @@ pref_defn!(
     32 => FreecamInvertYaw: bool,
     33 => FreecamInvertPitch: bool,
     34 => FreecamToggleWithZ: bool,
-    35 => FreecamSpeedMult: u8 = 3,
+    35 => FreecamSpeedMult: i16 = 3,
     36 => FreecamFreezeTimer: bool = true,
     37 => FreecamHideHud: bool = true,
     38 => HideHud: bool,
@@ -141,31 +141,31 @@ pref_defn!(
     42 => HideStobjs: bool,
     43 => HideEffects: bool,
     44 => IlMarkRomhacks: bool = true,
-    45 => Camera: u8,
-    46 => BallRed: u8,
-    47 => BallGreen: u8,
-    48 => BallBlue: u8,
-    49 => BallColorType: u8,
-    50 => ApeColorType: u8,
-    51 => InputDispColorType: u8,
-    52 => InputDispRed: u8,
-    53 => InputDispGreen: u8,
-    54 => InputDispBlue: u8,
-    55 => TimerType: u8,
+    45 => Camera: i16,
+    46 => BallRed: i16,
+    47 => BallGreen: i16,
+    48 => BallBlue: i16,
+    49 => BallColorType: i16,
+    50 => ApeColorType: i16,
+    51 => InputDispColorType: i16,
+    52 => InputDispRed: i16,
+    53 => InputDispGreen: i16,
+    54 => InputDispBlue: i16,
+    55 => TimerType: i16,
     56 => DisableFalloutVolumes: bool,
-    57 => FalloutPlaneType: u8,
+    57 => FalloutPlaneType: i16,
     58 => IlBattleShowTime: bool = true,
     59 => IlBattleShowScore: bool = true,
     60 => IlBattleBuzzerOld: bool,
-    61 => IlBattleBreakdown: u8,
-    62 => PhysicsPreset: u8,
+    61 => IlBattleBreakdown: i16,
+    62 => PhysicsPreset: i16,
     // 63 belonged to physics friction which was only used in beta playtesting
     // 64 belonged to physics restitution which was only used in beta playtesting
     // 65 belonged to SavestateDisableOverwrite
-    66 => MenuBind: u8 = 64,
-    67 => IlBattleReadyBind: u8 = 104,
-    68 => FreecamToggleBind: u8 = 255,
-    69 => SavestateClearBind: u8 = 255,
+    66 => MenuBind: i16 = 64,
+    67 => IlBattleReadyBind: i16 = 104,
+    68 => FreecamToggleBind: i16 = 255,
+    69 => SavestateClearBind: i16 = 255,
     70 => IlBattleTieCount: bool,
     71 => IlBattleAttemptCount: bool,
     72 => TimerShowSubtick: bool,
@@ -174,16 +174,16 @@ pref_defn!(
     // Many people playtested that beta, so it may be best to not reuse until
     // a future update
     75 => TimerShowPause: bool,
-    76 => StageEditVariant: u8,
+    76 => StageEditVariant: i16,
     77 => JumpChangePhysics: bool = true,
     78 => JumpAllowWalljumps: bool = true,
-    79 => JumpCount: u8 = 1,
+    79 => JumpCount: i16 = 1,
     // 80 belonged to physics weight which was only used in beta playtesting
-    81 => MonkeyType: u8,
-    82 => JumpProfile: u8,
+    81 => MonkeyType: i16,
+    82 => JumpProfile: i16,
     83 => CustomPhysicsDisp: bool = true,
-    84 => SavestateSaveTo: u8,
-    85 => SavestateClearAllBind: u8 = 255,
+    84 => SavestateSaveTo: i16,
+    85 => SavestateClearAllBind: i16 = 255,
 );
 
 const PREF_BUF_SIZE: usize =
@@ -206,13 +206,13 @@ impl PrefType<bool> for BoolPref {
     }
 }
 
-impl PrefType<u8> for U8Pref {
-    fn get(self, state: &PrefState) -> u8 {
-        Pref::get_u8_pref(self, state)
+impl PrefType<i16> for I16Pref {
+    fn get(self, state: &PrefState) -> i16 {
+        Pref::get_i16_pref(self, state)
     }
 
-    fn set(self, v: u8, pref: &mut Pref) {
-        Pref::set_u8_pref(self, &mut pref.curr_state, v);
+    fn set(self, v: i16, pref: &mut Pref) {
+        Pref::set_i16_pref(self, &mut pref.curr_state, v);
     }
 }
 
@@ -221,15 +221,15 @@ struct DefaultBool {
     value: bool,
 }
 
-struct DefaultU8 {
-    id: U8Pref,
-    value: u8,
+struct DefaultI16 {
+    id: I16Pref,
+    value: i16,
 }
 
 #[derive(Clone)]
 pub struct PrefState {
     bools: [u8; get_bit_array_len(BOOL_PREF_COUNT)],
-    u8s: [u8; U8_PREF_COUNT],
+    i16s: [i16; I16_PREF_COUNT],
 }
 
 impl Default for PrefState {
@@ -238,7 +238,7 @@ impl Default for PrefState {
     fn default() -> Self {
         Self {
             bools: [0; get_bit_array_len(BOOL_PREF_COUNT)],
-            u8s: [0; U8_PREF_COUNT],
+            i16s: [0; I16_PREF_COUNT],
         }
     }
 }
@@ -345,8 +345,8 @@ impl Pref {
 
             if let Some(bool_pref) = Self::pref_id_to_bool_pref(pref_id) {
                 entry.value = self.get(bool_pref) as u16;
-            } else if let Some(u8_pref) = Self::pref_id_to_u8_pref(pref_id) {
-                entry.value = self.get(u8_pref) as u16;
+            } else if let Some(i16_pref) = Self::pref_id_to_i16_pref(pref_id) {
+                entry.value = self.get(i16_pref) as u16;
             } else {
                 panic!("Failed to determine preference type");
             }
@@ -373,12 +373,8 @@ impl Pref {
             if let Ok(pref_id) = PrefId::try_from(entry.id) {
                 if let Some(bool_pref) = Self::pref_id_to_bool_pref(pref_id) {
                     Self::set_bool_pref(bool_pref, &mut self.curr_state, entry.value > 0);
-                } else if let Some(u8_pref) = Self::pref_id_to_u8_pref(pref_id) {
-                    Self::set_u8_pref(
-                        u8_pref,
-                        &mut self.curr_state,
-                        entry.value.try_into().unwrap_or(0),
-                    );
+                } else if let Some(i16_pref) = Self::pref_id_to_i16_pref(pref_id) {
+                    Self::set_i16_pref(i16_pref, &mut self.curr_state, entry.value as i16);
                 } else {
                     // Unknown preference type somehow, ignore
                 }
@@ -393,8 +389,8 @@ impl Pref {
         for default_bool in DEFAULT_BOOLS {
             Self::set_bool_pref(default_bool.id, &mut self.default_state, default_bool.value);
         }
-        for default_u8 in DEFAULT_U8S {
-            Self::set_u8_pref(default_u8.id, &mut self.default_state, default_u8.value);
+        for default_i16 in DEFAULT_I16S {
+            Self::set_i16_pref(default_i16.id, &mut self.default_state, default_i16.value);
         }
         self.curr_state = self.default_state.clone();
     }
@@ -404,8 +400,8 @@ impl Pref {
         val > 0
     }
 
-    fn get_u8_pref(u8_pref: U8Pref, state: &PrefState) -> u8 {
-        state.u8s[u8_pref as usize]
+    fn get_i16_pref(i16_pref: I16Pref, state: &PrefState) -> i16 {
+        state.i16s[i16_pref as usize]
     }
 
     fn set_bool_pref(bool_pref: BoolPref, state: &mut PrefState, val: bool) {
@@ -416,8 +412,8 @@ impl Pref {
         }
     }
 
-    fn set_u8_pref(u8_pref: U8Pref, state: &mut PrefState, val: u8) {
-        state.u8s[u8_pref as usize] = val;
+    fn set_i16_pref(i16_pref: I16Pref, state: &mut PrefState, val: i16) {
+        state.i16s[i16_pref as usize] = val;
     }
 
     pub fn get<T>(&self, pref: impl PrefType<T>) -> T {
@@ -486,15 +482,15 @@ impl Pref {
 }
 
 pub trait FromPref {
-    fn from_pref(pref_id: U8Pref, pref: &Pref) -> Self;
+    fn from_pref(pref_id: I16Pref, pref: &Pref) -> Self;
 }
 
 impl<T, E> FromPref for T
 where
-    T: TryFrom<u8, Error = E>,
+    T: TryFrom<i16, Error = E>,
     E: core::fmt::Debug,
 {
-    fn from_pref(pref_id: U8Pref, pref: &Pref) -> T {
+    fn from_pref(pref_id: I16Pref, pref: &Pref) -> T {
         let default = T::try_from(pref.get_default(pref_id)).unwrap();
         T::try_from(pref.get(pref_id)).unwrap_or(default)
     }


### PR DESCRIPTION
Make integer preferences i16-based instead of u8-based. This takes no additional storage in the pref file (they were u16 to begin with), and barely more RAM. This simply gives us a bigger range to work with, and it's perfectly backwards compatible.